### PR TITLE
Feature/cracked aetherheart into dev

### DIFF
--- a/src/main/java/thewarforged/actions/attackactions/AetherDischargeAction_Warforged.java
+++ b/src/main/java/thewarforged/actions/attackactions/AetherDischargeAction_Warforged.java
@@ -12,7 +12,7 @@ import com.megacrit.cardcrawl.vfx.combat.CleaveEffect;
 import com.megacrit.cardcrawl.vfx.combat.WhirlwindEffect;
 import thewarforged.util.CardStats;
 
-public class AetherDischargeAction extends AbstractGameAction {
+public class AetherDischargeAction_Warforged extends AbstractGameAction {
     public int[] multiDamage;
 
     private final boolean freeToPlayOnce;
@@ -25,7 +25,7 @@ public class AetherDischargeAction extends AbstractGameAction {
     private final boolean isUpgraded;
 
     // CONSTRUCTOR
-    public AetherDischargeAction(
+    public AetherDischargeAction_Warforged(
             AbstractPlayer player,
             int[] multiDamage,
             DamageInfo.DamageType damageType,

--- a/src/main/java/thewarforged/actions/utilactions/GainEnergyAction_Warforged.java
+++ b/src/main/java/thewarforged/actions/utilactions/GainEnergyAction_Warforged.java
@@ -6,29 +6,37 @@ import com.megacrit.cardcrawl.relics.AbstractRelic;
 import thewarforged.relics.starterRelics.CrackedAetherheartRelic_Warforged;
 
 public class GainEnergyAction_Warforged extends GainEnergyAction {
-    private final boolean wasTriggeredByCardPlay;
+    private final boolean shouldDelayAetherburn;
 
     public GainEnergyAction_Warforged(int amount) {
         super(amount);
-        this.wasTriggeredByCardPlay = true;
+        this.shouldDelayAetherburn = false;
     }
 
-    public GainEnergyAction_Warforged(int amount, boolean wasTriggeredByCardPlay) {
+    public GainEnergyAction_Warforged(int amount, boolean shouldDelayAetherburn) {
         super(amount);
-        this.wasTriggeredByCardPlay = wasTriggeredByCardPlay;
+        this.shouldDelayAetherburn = shouldDelayAetherburn;
     }
 
     @Override
     public void update() {
         super.update();
-        //If this Warforged-specific GainEnergyAction was triggered by a card being played by the Warforged,
-        if (this.wasTriggeredByCardPlay) {
-            // then find its Cracked Aetherheart relic and trigger Aetherburn.
-            AbstractRelic crackedAetherheartRelic =
-                    AbstractDungeon.player.getRelic("${modID}:CrackedAetherheartRelic_Warforged");
-            if (crackedAetherheartRelic instanceof CrackedAetherheartRelic_Warforged) {
-                ((CrackedAetherheartRelic_Warforged) crackedAetherheartRelic).runawayAetherheart_Aetherburn();
-            }
+        //Find the character's Cracked Heart relic.
+        AbstractRelic crackedAetherheartRelic =
+                AbstractDungeon.player.getRelic(CrackedAetherheartRelic_Warforged.ID);
+        //If it could not be found, then we're done here.
+        if (!(crackedAetherheartRelic instanceof CrackedAetherheartRelic_Warforged)) return;
+
+        //If this Warforged-specific GainEnergyAction should delay the aetherburn trigger,
+        if (this.shouldDelayAetherburn) {
+            // then create an action that will trigger it and add it to the bottom of the queue.
+            TriggerAetherburnAction_Warforged triggerAetherburnAction_warforged =
+                    new TriggerAetherburnAction_Warforged( (CrackedAetherheartRelic_Warforged) crackedAetherheartRelic);
+            this.addToBot(triggerAetherburnAction_warforged);
+            //Else, trigger is immediately.
+        } else {
+            ((CrackedAetherheartRelic_Warforged) crackedAetherheartRelic).runawayAetherheart_Aetherburn();
         }
+        this.isDone = true;
     }
 }

--- a/src/main/java/thewarforged/actions/utilactions/GainEnergyAction_Warforged.java
+++ b/src/main/java/thewarforged/actions/utilactions/GainEnergyAction_Warforged.java
@@ -35,7 +35,7 @@ public class GainEnergyAction_Warforged extends GainEnergyAction {
             this.addToBot(triggerAetherburnAction_warforged);
             //Else, trigger is immediately.
         } else {
-            ((CrackedAetherheartRelic_Warforged) crackedAetherheartRelic).runawayAetherheart_Aetherburn();
+            ((CrackedAetherheartRelic_Warforged) crackedAetherheartRelic).volatileAether_Aetherburn();
         }
         this.isDone = true;
     }

--- a/src/main/java/thewarforged/actions/utilactions/GainEnergyAction_Warforged.java
+++ b/src/main/java/thewarforged/actions/utilactions/GainEnergyAction_Warforged.java
@@ -1,0 +1,34 @@
+package thewarforged.actions.utilactions;
+
+import com.megacrit.cardcrawl.actions.common.GainEnergyAction;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+import thewarforged.relics.starterRelics.CrackedAetherheartRelic_Warforged;
+
+public class GainEnergyAction_Warforged extends GainEnergyAction {
+    private final boolean wasTriggeredByCardPlay;
+
+    public GainEnergyAction_Warforged(int amount) {
+        super(amount);
+        this.wasTriggeredByCardPlay = true;
+    }
+
+    public GainEnergyAction_Warforged(int amount, boolean wasTriggeredByCardPlay) {
+        super(amount);
+        this.wasTriggeredByCardPlay = wasTriggeredByCardPlay;
+    }
+
+    @Override
+    public void update() {
+        super.update();
+        //If this Warforged-specific GainEnergyAction was triggered by a card being played by the Warforged,
+        if (this.wasTriggeredByCardPlay) {
+            // then find its Cracked Aetherheart relic and trigger Aetherburn.
+            AbstractRelic crackedAetherheartRelic =
+                    AbstractDungeon.player.getRelic("${modID}:CrackedAetherheartRelic_Warforged");
+            if (crackedAetherheartRelic instanceof CrackedAetherheartRelic_Warforged) {
+                ((CrackedAetherheartRelic_Warforged) crackedAetherheartRelic).runawayAetherheart_Aetherburn();
+            }
+        }
+    }
+}

--- a/src/main/java/thewarforged/actions/utilactions/TriggerAetherburnAction_Warforged.java
+++ b/src/main/java/thewarforged/actions/utilactions/TriggerAetherburnAction_Warforged.java
@@ -14,7 +14,7 @@ public class TriggerAetherburnAction_Warforged extends AbstractGameAction {
     @Override
     public void update() {
         if (this.crackedAetherheartRelic != null) {
-            this.crackedAetherheartRelic.runawayAetherheart_Aetherburn();
+            this.crackedAetherheartRelic.volatileAether_Aetherburn();
         } else {
             final String errorStr =
                     "Bad reference to CrackedAetherheartRelic_Warforged passed to TriggerAetherburnAction_Warforged.";

--- a/src/main/java/thewarforged/actions/utilactions/TriggerAetherburnAction_Warforged.java
+++ b/src/main/java/thewarforged/actions/utilactions/TriggerAetherburnAction_Warforged.java
@@ -1,0 +1,25 @@
+package thewarforged.actions.utilactions;
+
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import thewarforged.relics.starterRelics.CrackedAetherheartRelic_Warforged;
+import thewarforged.util.GeneralUtils;
+
+public class TriggerAetherburnAction_Warforged extends AbstractGameAction {
+    private final CrackedAetherheartRelic_Warforged crackedAetherheartRelic;
+
+    public TriggerAetherburnAction_Warforged(CrackedAetherheartRelic_Warforged crackedAetherheartRelic) {
+        this.crackedAetherheartRelic = crackedAetherheartRelic;
+    }
+
+    @Override
+    public void update() {
+        if (this.crackedAetherheartRelic != null) {
+            this.crackedAetherheartRelic.runawayAetherheart_Aetherburn();
+        } else {
+            final String errorStr =
+                    "Bad reference to CrackedAetherheartRelic_Warforged passed to TriggerAetherburnAction_Warforged.";
+            GeneralUtils.easyPrint(errorStr);
+        }
+        this.isDone = true;
+    }
+}

--- a/src/main/java/thewarforged/cards/attackCards/AetherDischarge_Warforged.java
+++ b/src/main/java/thewarforged/cards/attackCards/AetherDischarge_Warforged.java
@@ -2,7 +2,7 @@ package thewarforged.cards.attackCards;
 
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
-import thewarforged.actions.attackactions.AetherDischargeAction;
+import thewarforged.actions.attackactions.AetherDischargeAction_Warforged;
 import thewarforged.cards.AbstractWarforgedCard;
 import thewarforged.character.TheWarforged;
 import thewarforged.util.CardStats;
@@ -33,7 +33,7 @@ public class AetherDischarge_Warforged extends AbstractWarforgedCard {
 
     @Override
     public void use(AbstractPlayer player, AbstractMonster monster) {
-        AetherDischargeAction aetherDischargeAction = new AetherDischargeAction(
+        AetherDischargeAction_Warforged aetherDischargeActionWarforged = new AetherDischargeAction_Warforged(
                 //The source of this damage.
                 player,
                 //An array of integers representing the damage being applied to the multiple targets of this attack.
@@ -49,6 +49,6 @@ public class AetherDischarge_Warforged extends AbstractWarforgedCard {
                 //Whether this card has been upgraded.
                 this.upgraded
         );
-        addToBot(aetherDischargeAction);
+        addToBot(aetherDischargeActionWarforged);
     }
 }

--- a/src/main/java/thewarforged/character/TheWarforged.java
+++ b/src/main/java/thewarforged/character/TheWarforged.java
@@ -24,6 +24,7 @@ import thewarforged.cards.attackCards.DirectCurrent_Warforged;
 import thewarforged.cards.attackCards.Strike_Warforged;
 import thewarforged.cards.skillCards.Defend_Warforged;
 import thewarforged.cards.skillCards.RaiseShields_Warforged;
+import thewarforged.relics.starterRelics.CrackedAetherheartRelic_Warforged;
 
 import java.util.ArrayList;
 
@@ -154,7 +155,7 @@ public class TheWarforged extends CustomPlayer {
     public ArrayList<String> getStartingRelics() {
         ArrayList<String> retVal = new ArrayList<>();
         //IDs of starting relics. You can have multiple, but one is recommended.
-        retVal.add(BurningBlood.ID);
+        retVal.add(CrackedAetherheartRelic_Warforged.ID);
 
         return retVal;
     }

--- a/src/main/java/thewarforged/character/TheWarforged.java
+++ b/src/main/java/thewarforged/character/TheWarforged.java
@@ -12,18 +12,17 @@ import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
-import com.megacrit.cardcrawl.core.EnergyManager;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.helpers.CardLibrary;
 import com.megacrit.cardcrawl.helpers.FontHelper;
 import com.megacrit.cardcrawl.helpers.ScreenShake;
-import com.megacrit.cardcrawl.relics.BurningBlood;
 import com.megacrit.cardcrawl.screens.CharSelectInfo;
 import thewarforged.cards.attackCards.AetherDischarge_Warforged;
 import thewarforged.cards.attackCards.DirectCurrent_Warforged;
 import thewarforged.cards.attackCards.Strike_Warforged;
 import thewarforged.cards.skillCards.Defend_Warforged;
 import thewarforged.cards.skillCards.RaiseShields_Warforged;
+import thewarforged.core.EnergyManager_Warforged;
 import thewarforged.relics.starterRelics.CrackedAetherheartRelic_Warforged;
 
 import java.util.ArrayList;
@@ -33,8 +32,8 @@ import static thewarforged.TheWarforgedMod.makeID;
 
 public class TheWarforged extends CustomPlayer {
     //Stats
-    public static final int ENERGY_PER_TURN = 3;
-    public static final int MAX_HP = 70;
+    public static final int ENERGY_PER_TURN = 0;
+    public static final int MAX_HP = 75;
     public static final int STARTING_GOLD = 99;
     public static final int CARD_DRAW = 5;
     public static final int ORB_SLOTS = 0;
@@ -116,6 +115,18 @@ public class TheWarforged extends CustomPlayer {
             360.0F
     };
 
+    //Our custom EnergyManager_Warforged. When loading into a preexisting save, this gets overwritten by the
+    // default EnergyManager, so we have to apply it back to the player. Use the energyManager_Warforged() method
+    // to ensure this is not null when retrieved.
+    private EnergyManager_Warforged _energyManager_Warforged;
+
+    public EnergyManager_Warforged energyManager_Warforged() {
+        if (this._energyManager_Warforged == null) {
+            this._energyManager_Warforged = new EnergyManager_Warforged(ENERGY_PER_TURN);
+        }
+        return this._energyManager_Warforged;
+    }
+
 
     //Actual character class code below this point
 
@@ -130,7 +141,7 @@ public class TheWarforged extends CustomPlayer {
                 CORPSE,
                 getLoadout(),
                 20.0F, -20.0F, 200.0F, 250.0F, //Character hitbox. x y position, then width and height.
-                new EnergyManager(ENERGY_PER_TURN));
+                this.energyManager_Warforged());
 
         //Location for text bubbles. You can adjust it as necessary later. For most characters, these values are fine.
         dialogX = (drawX + 0.0F * Settings.scale);

--- a/src/main/java/thewarforged/character/TheWarforged.java
+++ b/src/main/java/thewarforged/character/TheWarforged.java
@@ -32,7 +32,9 @@ import static thewarforged.TheWarforgedMod.makeID;
 
 public class TheWarforged extends CustomPlayer {
     //Stats
-    public static final int ENERGY_PER_TURN = 0;
+    //This ENERGY_PER_TURN is meant to be standard *just in case* the Warforged character somehow gets played
+    // without its CrackedAetherheart relic, since gaining no energy per turn is a fundamental part of its mechanics.
+    public static final int ENERGY_PER_TURN = 3;
     public static final int MAX_HP = 75;
     public static final int STARTING_GOLD = 99;
     public static final int CARD_DRAW = 5;
@@ -115,18 +117,6 @@ public class TheWarforged extends CustomPlayer {
             360.0F
     };
 
-    //Our custom EnergyManager_Warforged. When loading into a preexisting save, this gets overwritten by the
-    // default EnergyManager, so we have to apply it back to the player. Use the energyManager_Warforged() method
-    // to ensure this is not null when retrieved.
-    private EnergyManager_Warforged _energyManager_Warforged;
-
-    public EnergyManager_Warforged energyManager_Warforged() {
-        if (this._energyManager_Warforged == null) {
-            this._energyManager_Warforged = new EnergyManager_Warforged(ENERGY_PER_TURN);
-        }
-        return this._energyManager_Warforged;
-    }
-
 
     //Actual character class code below this point
 
@@ -141,7 +131,7 @@ public class TheWarforged extends CustomPlayer {
                 CORPSE,
                 getLoadout(),
                 20.0F, -20.0F, 200.0F, 250.0F, //Character hitbox. x y position, then width and height.
-                this.energyManager_Warforged());
+                new EnergyManager_Warforged(ENERGY_PER_TURN));
 
         //Location for text bubbles. You can adjust it as necessary later. For most characters, these values are fine.
         dialogX = (drawX + 0.0F * Settings.scale);

--- a/src/main/java/thewarforged/core/EnergyManager_Warforged.java
+++ b/src/main/java/thewarforged/core/EnergyManager_Warforged.java
@@ -1,0 +1,77 @@
+package thewarforged.core;
+
+import com.megacrit.cardcrawl.actions.GameActionManager;
+import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.core.EnergyManager;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+import com.megacrit.cardcrawl.ui.panels.EnergyPanel;
+import thewarforged.relics.starterRelics.CrackedAetherheartRelic_Warforged;
+import thewarforged.util.GeneralUtils;
+
+public class EnergyManager_Warforged extends EnergyManager {
+
+    AbstractPlayer _player;
+    CrackedAetherheartRelic_Warforged _crackedAetherheartRelic;
+    GameActionManager _actionManager;
+
+    public EnergyManager_Warforged(int energy) {
+        super(energy);
+    }
+
+    private AbstractPlayer player() {
+        if (this._player == null) this._player = AbstractDungeon.player;
+        return this._player;
+    }
+
+    private CrackedAetherheartRelic_Warforged crackedAetherheartRelic() {
+        if (this._crackedAetherheartRelic == null) {
+            AbstractRelic tmp = this.player().getRelic(CrackedAetherheartRelic_Warforged.ID);
+            if (tmp instanceof CrackedAetherheartRelic_Warforged) {
+                this._crackedAetherheartRelic = (CrackedAetherheartRelic_Warforged) tmp;
+            } else {
+                this._crackedAetherheartRelic = null;
+            }
+        }
+        return this._crackedAetherheartRelic;
+    }
+
+    private GameActionManager actionManager() {
+        if (this._actionManager == null) this._actionManager = AbstractDungeon.actionManager;
+        return this._actionManager;
+    }
+
+    /**
+     * Rather than patch the base class's recharge method, we override it to either work exactly like normal (if
+     * the character doesn't have the Cracked Aetherheart relic for some reason) or to simulate the same interaction
+     * it would normally have with Ice Cream, since this relic has the same effect.
+     */
+    @Override
+    public void recharge() {
+        GeneralUtils.easyPrint("1 ---- " + EnergyPanel.totalCount);
+        //If the character has the Cracked Aetherheart relic,
+        if (this.crackedAetherheartRelic() != null) {
+            GeneralUtils.easyPrint("2 ---- " + EnergyPanel.totalCount);
+            // then treat them the same as if they had the Ice Cream relic.
+            if (EnergyPanel.totalCount > 0) {
+                GeneralUtils.easyPrint("3 ---- " + EnergyPanel.totalCount);
+                this.crackedAetherheartRelic().flash();
+                RelicAboveCreatureAction relicAboveCreatureAction =
+                        new RelicAboveCreatureAction(this.player(), this.crackedAetherheartRelic());
+                this.actionManager().addToTop(relicAboveCreatureAction);
+                GeneralUtils.easyPrint("4 ---- " + EnergyPanel.totalCount);
+            }
+            GeneralUtils.easyPrint("5 ---- " + EnergyPanel.totalCount);
+            //This should be adding zero, unless the character's core design has changed.
+            EnergyPanel.addEnergy(this.energy);
+            GeneralUtils.easyPrint("6 ---- " + EnergyPanel.totalCount);
+            this.actionManager().updateEnergyGain(this.energy);
+            GeneralUtils.easyPrint("7 ---- " + EnergyPanel.totalCount);
+        } else {
+            //Character did not have the Cracked Aetherheart relic. Just call the super's recharge like normal.
+            super.recharge();
+        }
+
+    }
+}

--- a/src/main/java/thewarforged/patches/EnergyPanelPatches.java
+++ b/src/main/java/thewarforged/patches/EnergyPanelPatches.java
@@ -1,8 +1,14 @@
 package thewarforged.patches;
 
+import com.evacipated.cardcrawl.modthespire.lib.SpireInstrumentPatch;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePatch2;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
+import com.megacrit.cardcrawl.core.EnergyManager;
 import com.megacrit.cardcrawl.ui.panels.EnergyPanel;
+import javassist.CannotCompileException;
+import javassist.expr.ExprEditor;
+import javassist.expr.MethodCall;
+import thewarforged.util.GeneralUtils;
 
 public class EnergyPanelPatches {
 
@@ -63,4 +69,22 @@ public class EnergyPanelPatches {
             onEnergyChanged();
         }
     }
+
+//    @SpirePatch2(
+//            clz = EnergyManager.class,
+//            method = "recharge"
+//    )
+//    public static class CheckWarforgedRelicDuringRechargePatch {
+//        public CheckWarforgedRelicDuringRechargePatch() {
+//        }
+//
+//        @SpireInstrumentPatch
+//        public static ExprEditor Instrument() {
+//            return new ExprEditor() {
+//                public void edit(MethodCall m) throws CannotCompileException {
+//                    if (m.getMethodName().equals("recharge"))
+//                }
+//            };
+//        }
+//    }
 }

--- a/src/main/java/thewarforged/patches/EnergyPanelPatches.java
+++ b/src/main/java/thewarforged/patches/EnergyPanelPatches.java
@@ -1,0 +1,66 @@
+package thewarforged.patches;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch2;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
+import com.megacrit.cardcrawl.ui.panels.EnergyPanel;
+
+public class EnergyPanelPatches {
+
+    private static void onEnergyChanged() {
+        int currentEnergy = EnergyPanel.getCurrentEnergy();
+    }
+
+    /**
+     * Adds a call to my postfix method to the end of the setEnergy method of the EnergyPanel class.
+     * The only thing this postfix method does is call my onEnergyChanged method.
+     */
+    @SpirePatch2(
+            clz = EnergyPanel.class,
+            method = "setEnergy"
+    )
+    public static class EnergyChangeViaSetEnergyPatch {
+        public EnergyChangeViaSetEnergyPatch() {
+        }
+
+        @SpirePostfixPatch
+        public static void postfix() {
+            onEnergyChanged();
+        }
+    }
+
+    /**
+     * Adds a call to my postfix method to the end of the addEnergy method of the EnergyPanel class.
+     * The only thing this postfix method does is call my onEnergyChanged method.
+     */
+    @SpirePatch2(
+            clz = EnergyPanel.class,
+            method = "addEnergy"
+    )
+    public static class EnergyChangeViaAddEnergyPatch {
+        public EnergyChangeViaAddEnergyPatch() {
+        }
+
+        @SpirePostfixPatch
+        public static void postfix() {
+            onEnergyChanged();
+        }
+    }
+
+    /**
+     * Adds a call to my postfix method to the end of the useEnergy method of the EnergyPanel class.
+     * The only thing this postfix method does is call my onEnergyChanged method.
+     */
+    @SpirePatch2(
+            clz = EnergyPanel.class,
+            method = "useEnergy"
+    )
+    public static class EnergyChangeViaUseEnergyPatch {
+        public EnergyChangeViaUseEnergyPatch() {
+        }
+
+        @SpirePostfixPatch
+        public static void postfix() {
+            onEnergyChanged();
+        }
+    }
+}

--- a/src/main/java/thewarforged/powers/IonizedPower_Warforged.java
+++ b/src/main/java/thewarforged/powers/IonizedPower_Warforged.java
@@ -9,7 +9,6 @@ import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.powers.AbstractPower;
-import thewarforged.util.GeneralUtils;
 
 import static thewarforged.TheWarforgedMod.makeID;
 
@@ -32,7 +31,6 @@ public class IonizedPower_Warforged extends AbstractWarforgedPower {
     @Override
     public void onAttack(DamageInfo info, int damageAmount, AbstractCreature target) {
         if (info.type != DamageInfo.DamageType.NORMAL || target == info.owner) {
-            GeneralUtils.easyPrint("Not a valid attack for Ionized damage. Damage type: " + info.type);
             return;
         }
 
@@ -42,10 +40,8 @@ public class IonizedPower_Warforged extends AbstractWarforgedPower {
         //I believe that the check for it being 0 is just an abundance of caution, but the base game does it
         // with powers like Vulnerable, so I will imitate them.
         if (this.amount <= 0) {
-            GeneralUtils.easyPrint("Amount was <= 0, so adding action to remove the power.");
             this.addToTop(new RemoveSpecificPowerAction(this.owner, this.owner, POWER_ID));
         } else {
-            GeneralUtils.easyPrint("Amount was > 0, so adding action to decrement the power by 1.");
             //Because we are adding these to the top of the queue, and this should happen *after* the
             // damage action, this needs to be added first. Same with the RemoveSpecificPowerAction above.
             this.addToTop(new ReducePowerAction(this.owner, this.owner, POWER_ID, 1));

--- a/src/main/java/thewarforged/relics/AbstractWarforgedRelic.java
+++ b/src/main/java/thewarforged/relics/AbstractWarforgedRelic.java
@@ -1,0 +1,35 @@
+package thewarforged.relics;
+
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import thewarforged.character.TheWarforged;
+
+public abstract class AbstractWarforgedRelic extends BaseRelic {
+
+    /**
+     * This constructor is used for character-specific relics.
+     * @param id The ID of this relic, made in each relic class with `makeID(NAME)`
+     * @param imageName The name of the image to use for this relic (should be the same name as the relic)
+     * @param tier The rarity of the relic
+     * @param sfx The sound played when the relic is picked up/clicked
+     */
+    public AbstractWarforgedRelic(
+            String id,
+            String imageName,
+            RelicTier tier,
+            LandingSound sfx) {
+        super(id, imageName, TheWarforged.Meta.CARD_COLOR, tier, sfx);
+    }
+
+    /**
+     * This constructor is used for general relics.
+     * @param id The ID of this relic, made in each relic class with `makeID(NAME)`
+     * @param tier The rarity of the relic
+     * @param sfx The sound played when the relic is picked up/clicked
+     */
+    public AbstractWarforgedRelic(
+            String id,
+            RelicTier tier,
+            LandingSound sfx) {
+        super(id, tier, sfx);
+    }
+}

--- a/src/main/java/thewarforged/relics/starterRelics/CrackedAetherheartRelic_Warforged.java
+++ b/src/main/java/thewarforged/relics/starterRelics/CrackedAetherheartRelic_Warforged.java
@@ -1,0 +1,27 @@
+package thewarforged.relics.starterRelics;
+
+import com.megacrit.cardcrawl.actions.common.GainEnergyAction;
+import com.megacrit.cardcrawl.actions.utility.UseCardAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import thewarforged.relics.AbstractWarforgedRelic;
+
+import static thewarforged.TheWarforgedMod.makeID;
+
+public class CrackedAetherheartRelic_Warforged extends AbstractWarforgedRelic {
+    private static final String NAME = "CrackedAetherheart_Warforged";
+    public static final String ID = makeID(NAME);
+    private static final RelicTier RARITY = RelicTier.STARTER;
+    private static final LandingSound LANDING_SOUND = LandingSound.CLINK;
+
+    private static final int ENERGY_ON_CARD_PLAY = 1;
+
+    public CrackedAetherheartRelic_Warforged() {
+        //The second argument, NAME, is the name of both this relic and the image for this relic.
+        super(ID, NAME, RARITY, LANDING_SOUND);
+    }
+
+    @Override
+    public void onUseCard(AbstractCard targetCard, UseCardAction useCardAction) {
+        GainEnergyAction gainEnergyAction = new GainEnergyAction(ENERGY_ON_CARD_PLAY);
+    }
+}

--- a/src/main/java/thewarforged/relics/starterRelics/CrackedAetherheartRelic_Warforged.java
+++ b/src/main/java/thewarforged/relics/starterRelics/CrackedAetherheartRelic_Warforged.java
@@ -1,27 +1,237 @@
 package thewarforged.relics.starterRelics;
 
-import com.megacrit.cardcrawl.actions.common.GainEnergyAction;
+import com.megacrit.cardcrawl.actions.GameActionManager;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.common.LoseHPAction;
+import com.megacrit.cardcrawl.actions.common.ReducePowerAction;
 import com.megacrit.cardcrawl.actions.utility.UseCardAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardQueueItem;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+import com.megacrit.cardcrawl.powers.DexterityPower;
+import com.megacrit.cardcrawl.powers.StrengthPower;
+import com.megacrit.cardcrawl.ui.panels.EnergyPanel;
+import thewarforged.actions.utilactions.GainEnergyAction_Warforged;
 import thewarforged.relics.AbstractWarforgedRelic;
 
 import static thewarforged.TheWarforgedMod.makeID;
 
 public class CrackedAetherheartRelic_Warforged extends AbstractWarforgedRelic {
-    private static final String NAME = "CrackedAetherheart_Warforged";
+    private static final String NAME = CrackedAetherheartRelic_Warforged.class.getSimpleName();
     public static final String ID = makeID(NAME);
     private static final RelicTier RARITY = RelicTier.STARTER;
     private static final LandingSound LANDING_SOUND = LandingSound.CLINK;
 
-    private static final int ENERGY_ON_CARD_PLAY = 1;
+    private AbstractPlayer _player;
+    private GameActionManager _actionManager;
+
+    private final int STARTING_DEX = 2;
+    private final int STARTING_STR = -2;
+    private final int NUM_ENERGY_PER_TIER = 2;
+
+    private int numDexApplied = 0;
+    private int numStrApplied = 0;
+
+    private final int MAX_SAFE_ENERGY = 6;
+    private final int DAMAGE_PER_ENERGY_PAST_MAX = 1;
+
+    private final int NUM_CARDS_FOR_OVERLOAD = 6;
+    private final int NUM_CARDS_FOR_RESET = NUM_CARDS_FOR_OVERLOAD + 1;
+    private int numCardsPlayed = 0;
+
+    private final int STARTING_ENERGY_GAIN = 1;
+    private final int OVERLOAD_ENERGY_GAIN_MULTIPLIER = 2;
+    private int currentEnergyGain = STARTING_ENERGY_GAIN;
 
     public CrackedAetherheartRelic_Warforged() {
         //The second argument, NAME, is the name of both this relic and the image for this relic.
         super(ID, NAME, RARITY, LANDING_SOUND);
     }
 
+    private AbstractPlayer player() {
+        if (this._player == null) this._player = AbstractDungeon.player;
+        return this._player;
+    }
+
+    private GameActionManager actionManager() {
+        if (this._actionManager == null) this._actionManager = AbstractDungeon.actionManager;
+        return this._actionManager;
+    }
+
+    @Override
+    public void atPreBattle() {
+
+    }
+
+    /**
+     * This happens BEFORE the card's effects (before `use`).
+     * @param card The card that the player played.
+     * @param monster The monster that was targeted by the card.
+     */
+    @Override
+    public void onPlayCard(AbstractCard card, AbstractMonster monster) {
+        //TODO: Set starting stuff.
+    }
+
+    /**
+     * This happens AFTER a card's effects (after `use`).
+     * @param targetCard The card that was used
+     * @param useCardAction The action that was on the stack to be used in the previous use action.
+     */
     @Override
     public void onUseCard(AbstractCard targetCard, UseCardAction useCardAction) {
-        GainEnergyAction gainEnergyAction = new GainEnergyAction(ENERGY_ON_CARD_PLAY);
+        //A card was played! Track the number of cards played for the overload mechanic.
+        this.runawayAetherheart_IncreaseCharge(targetCard, useCardAction);
+        //If the number of cards played is NOT back to 0 (after being tracked and possibly reset above),
+        if (this.numCardsPlayed != 0) {
+            // then this card was NOT the overload (copy) card, and therefore counts for energy gain/aetherburn.
+            this.runawayAetherheart_GainEnergy();
+        }
+    }
+
+    /**
+     * The aetherheart is spinning wildly and generating dangerous amounts of energy!
+     * The character gains energy. The amount gained increases dramatically as they play
+     * more and more cards in the same turn.
+     */
+    private void runawayAetherheart_GainEnergy() {
+        //This action will trigger aetherburn after the energy is gained.
+        GainEnergyAction_Warforged gainEnergyAction = new GainEnergyAction_Warforged(this.currentEnergyGain);
+        this.addToTop(gainEnergyAction);
+    }
+
+    /**
+     * Balances the Dex/Str on the Warforged according to the current energy tier. For every tier,
+     * Dexterity reduces by 1 and Strength increases by 1. When energy is lost, rewinds those differences.
+     */
+    private void runawayAetherheart_BalancePowers() {
+        int newDex;
+        int newStr;
+
+        int currEnergy = EnergyPanel.getCurrentEnergy();
+        int currEnergyTier = currEnergy / this.NUM_ENERGY_PER_TIER;
+
+        newDex = this.STARTING_DEX - currEnergyTier;
+        newStr = this.STARTING_STR + currEnergyTier;
+
+        this.setPowers(newDex, newStr);
+    }
+
+    /**
+     * Brings the character's Dex and Str up/down to the new values if necessary. Keeps track of Dex and Str that
+     *  have already been applied (positive and negative) so ensure Dex/Str buffs/debuffs from other sources are
+     *  not affected. Loss of Dex/Str in this manner is not considered a debuff in order to avoid odd
+     *  interactions with Artifact.
+     * @param newDex The amount of Dexterity that should be applied to the character from this relic
+     *               (ignores Dexterity from other sources)
+     * @param newStr The amount of Strength that should be applied to the character from this relic
+     *               (ignores Strength from other sources)
+     */
+    private void setPowers(int newDex, int newStr) {
+        //Get the current DexterityPower on the player, if any.
+        AbstractPower existingDexPower = this.player().getPower("Dexterity");
+        //Determine the difference between the current amount of Dex applied to the character via this relic and
+        // new amount that should be applied instead.
+        int dexDiff = newDex - this.numDexApplied;
+        //If the amount of Dex needs to drop, and they already have some Dex (either positive or negative),
+        if (dexDiff < 0 && existingDexPower != null) {
+            // then reduce the character's Dex power by that much.
+            ReducePowerAction reducePowerAction =
+                    new ReducePowerAction(this.player(), this.player(), existingDexPower, dexDiff);
+            this.addToBot(reducePowerAction);
+            // Else, either no change is required, or the character does not have any Dex at the moment.
+            // If a change is Dex is required,
+        } else if (dexDiff != 0) {
+            // then create a change to the current Dex power on the character to apply.
+            DexterityPower newDexPower = new DexterityPower(this.player(), dexDiff);
+            //Regardless of whether this is negative, count it as a BUFF so avoid odd interactions with Artifact.
+            newDexPower.type = AbstractPower.PowerType.BUFF;
+            ApplyPowerAction powerAction = new ApplyPowerAction(this.player(), this.player(), newDexPower, dexDiff);
+            this.addToBot(powerAction);
+        }
+        //Track the amount of Dex (positive, negative, or 0) that is currently applied to the character via this relic.
+        this.numDexApplied += dexDiff;
+
+        //Repeat the same as above, but for Str.
+        AbstractPower existingStrPower = this.player().getPower("Strength");
+        int strDiff = newStr - this.numStrApplied;
+        if (strDiff < 0 && existingStrPower != null) {
+            ReducePowerAction reducePowerAction =
+                    new ReducePowerAction(this.player(), this.player(), existingStrPower, strDiff);
+            this.addToBot(reducePowerAction);
+        } else if (strDiff != 0) {
+            StrengthPower newStrPower = new StrengthPower(this.player(), strDiff);
+            newStrPower.type = AbstractPower.PowerType.BUFF;
+            ApplyPowerAction powerAction = new ApplyPowerAction(this.player(), this.player(), newStrPower, strDiff);
+            this.addToBot(powerAction);
+        }
+        this.numStrApplied += strDiff;
+    }
+
+    public void runawayAetherheart_Aetherburn() {
+        int currEnergy = EnergyPanel.getCurrentEnergy();
+        int burnAmount = currEnergy - MAX_SAFE_ENERGY;
+        if (burnAmount > 0) {
+            this.addToBot(new LoseHPAction(this.player(), this.player(), burnAmount));
+        }
+    }
+
+    /**
+     * The aetherheart's energy builds toward an inevitable release of power!
+     * Tracks the number of cards played and, once it reaches a certain points, overloads the last card.
+     * Then the amount of energy gained per card played increases (multiplicative).
+     * @param targetCard The card that was last played by the character
+     */
+    private void runawayAetherheart_IncreaseCharge(AbstractCard targetCard, UseCardAction useCardAction) {
+        this.numCardsPlayed++;
+        if (numCardsPlayed == this.NUM_CARDS_FOR_OVERLOAD) {
+            //Overload this card and double the amount of energy gained per card played.
+            this.runawayAetherheart_Overload(targetCard, useCardAction);
+            this.currentEnergyGain *= this.OVERLOAD_ENERGY_GAIN_MULTIPLIER;
+            //If this is the card played immediately after overloading a card,
+        } else if (numCardsPlayed == this.NUM_CARDS_FOR_RESET) {
+            // then this is the overloaded card's copy. It does not count towards the next overload. Reset.
+            this.numCardsPlayed = 0;
+        }
+    }
+
+    /**
+     * The aetherheart cannot hold the energy any longer. It demands to be released.
+     * Duplicates the target card.
+     * @param targetCard The card to duplicate
+     */
+    private void runawayAetherheart_Overload(AbstractCard targetCard, UseCardAction useCardAction) {
+        //This follows the pattern shown in EchoPower.class, which doubles a card the same way overload should.
+        this.flash();
+        //Get the monster target of the card being copied, if one exists.
+        AbstractMonster monster = null;
+        if (useCardAction.target != null) {
+            monster = (AbstractMonster)useCardAction.target;
+        }
+
+        //Create the copy.
+        AbstractCard tempCard = targetCard.makeSameInstanceOf();
+        //Then place it into... limbo? I have no idea, but it's what EchoPower does. I will trust it for now.
+        this.player().limbo.addToBottom(tempCard);
+        //The rest of this section seems to be setting variables for screen placement/animation.
+        tempCard.current_x = targetCard.current_x;
+        tempCard.current_y = targetCard.current_y;
+        tempCard.target_x = (float) Settings.WIDTH / 2.0F - 300.0F * Settings.scale;
+        tempCard.target_y = (float) Settings.HEIGHT / 2.0F;
+
+        //Calculate damage if there is a monster to calculate against. I assume this does nothing if the card
+        // being copied targets a monster without damaging it. I haven't looked into it yet.
+        if (monster != null) {
+            tempCard.calculateCardDamage(monster);
+        }
+
+        //Ensure that this copy will disappear after being played, rather than added to the dungeon deck.
+        targetCard.purgeOnUse = true;
+        CardQueueItem cardQueueItem = new CardQueueItem(tempCard, monster, targetCard.energyOnUse, true, true);
+        this.actionManager().addCardQueueItem(cardQueueItem, true);
     }
 }

--- a/src/main/java/thewarforged/relics/starterRelics/CrackedAetherheartRelic_Warforged.java
+++ b/src/main/java/thewarforged/relics/starterRelics/CrackedAetherheartRelic_Warforged.java
@@ -111,13 +111,13 @@ public class CrackedAetherheartRelic_Warforged extends AbstractWarforgedRelic {
     @Override
     public void onUseCard(AbstractCard targetCard, UseCardAction useCardAction) {
         //A card was played! Track the number of cards played for the overload mechanic.
-        this.runawayAetherheart_IncreaseCharge(targetCard, useCardAction);
+        this.volatileAether_IncreaseCharge(targetCard, useCardAction);
         //If the number of cards played is NOT back to 0 (after being tracked and possibly reset above),
         if (this.numCardsPlayed != 0) {
             // then this card was NOT the overload (copy) card, and therefore counts for energy
             // gain/aetherburn. Delay the aetherburn for X_COST cards, though.
             boolean shouldDelayAetherburn = (targetCard.cost == CardStats.X_COST());
-            this.runawayAetherheart_GainEnergy(shouldDelayAetherburn);
+            this.volatileAether_GainEnergy(shouldDelayAetherburn);
         }
     }
 
@@ -126,7 +126,7 @@ public class CrackedAetherheartRelic_Warforged extends AbstractWarforgedRelic {
      * The character gains energy. The amount gained increases dramatically as they play
      * more and more cards in the same turn.
      */
-    private void runawayAetherheart_GainEnergy(boolean shouldDelayAetherburn) {
+    private void volatileAether_GainEnergy(boolean shouldDelayAetherburn) {
 
         //This action will trigger aetherburn after the energy is gained.
         GainEnergyAction_Warforged gainEnergyAction =
@@ -138,9 +138,9 @@ public class CrackedAetherheartRelic_Warforged extends AbstractWarforgedRelic {
      * Handles the HP loss triggered by having too much energy after playing a card. The energy gained by
      * playing a card via this relic is included in this calculation, and this method is called by that custom
      * GainEnergyAction_Warforged after the energy is applied. Once aetherburn is handled, this method calls
-     * runawayAetherheart_BalancePowers() to adjust the character's Dex/Str according to the new energy level.
+     * volatileAether_BalancePowers() to adjust the character's Dex/Str according to the new energy level.
      */
-    public void runawayAetherheart_Aetherburn() {
+    public void volatileAether_Aetherburn() {
         // Determine how much energy the character has past the maximum safe amount.
         int currEnergy = EnergyPanel.getCurrentEnergy();
         int aetherburn = currEnergy - MAX_SAFE_ENERGY;
@@ -155,14 +155,14 @@ public class CrackedAetherheartRelic_Warforged extends AbstractWarforgedRelic {
         }
 
         //After handling aetherburn, balance the character's Dex/Str based on new energy levels.
-        this.runawayAetherheart_BalancePowers();
+        this.volatileAether_BalancePowers();
     }
 
     /**
      * Balances the Dex/Str on the Warforged according to the current energy tier. For every tier,
      * Dexterity reduces by 1 and Strength increases by 1. When energy is lost, rewinds those differences.
      */
-    private void runawayAetherheart_BalancePowers() {
+    private void volatileAether_BalancePowers() {
         int newDex;
         int newStr;
 
@@ -233,11 +233,11 @@ public class CrackedAetherheartRelic_Warforged extends AbstractWarforgedRelic {
      * Then the amount of energy gained per card played increases (multiplicative).
      * @param targetCard The card that was last played by the character
      */
-    private void runawayAetherheart_IncreaseCharge(AbstractCard targetCard, UseCardAction useCardAction) {
+    private void volatileAether_IncreaseCharge(AbstractCard targetCard, UseCardAction useCardAction) {
         this.numCardsPlayed++;
         if (numCardsPlayed == this.NUM_CARDS_FOR_OVERLOAD) {
             //Overload this card and double the amount of energy gained per card played.
-            this.runawayAetherheart_Overload(targetCard, useCardAction);
+            this.volatileAether_Overload(targetCard, useCardAction);
             this.currentEnergyGain *= this.OVERLOAD_ENERGY_GAIN_MULTIPLIER;
             //If this is the card played immediately after overloading a card,
         } else if (numCardsPlayed == this.NUM_CARDS_FOR_RESET) {
@@ -251,7 +251,7 @@ public class CrackedAetherheartRelic_Warforged extends AbstractWarforgedRelic {
      * Duplicates the target card.
      * @param targetCard The card to duplicate
      */
-    private void runawayAetherheart_Overload(AbstractCard targetCard, UseCardAction useCardAction) {
+    private void volatileAether_Overload(AbstractCard targetCard, UseCardAction useCardAction) {
         //This follows the pattern shown in EchoPower.class, which doubles a card the same way overload should.
         this.flash();
         //Get the monster target of the card being copied, if one exists.

--- a/src/main/java/thewarforged/relics/starterRelics/CrackedAetherheartRelic_Warforged.java
+++ b/src/main/java/thewarforged/relics/starterRelics/CrackedAetherheartRelic_Warforged.java
@@ -18,14 +18,13 @@ import com.megacrit.cardcrawl.powers.DexterityPower;
 import com.megacrit.cardcrawl.powers.StrengthPower;
 import com.megacrit.cardcrawl.ui.panels.EnergyPanel;
 import thewarforged.actions.utilactions.GainEnergyAction_Warforged;
-import thewarforged.character.TheWarforged;
 import thewarforged.core.EnergyManager_Warforged;
 import thewarforged.relics.AbstractWarforgedRelic;
 import thewarforged.util.CardStats;
-import thewarforged.util.GeneralUtils;
 
 import static thewarforged.TheWarforgedMod.makeID;
 
+@SuppressWarnings("FieldCanBeLocal")
 public class CrackedAetherheartRelic_Warforged extends AbstractWarforgedRelic {
     private static final String NAME = CrackedAetherheartRelic_Warforged.class.getSimpleName();
     public static final String ID = makeID(NAME);

--- a/src/main/java/thewarforged/relics/starterRelics/CrackedAetherheartRelic_Warforged.java
+++ b/src/main/java/thewarforged/relics/starterRelics/CrackedAetherheartRelic_Warforged.java
@@ -69,7 +69,15 @@ public class CrackedAetherheartRelic_Warforged extends AbstractWarforgedRelic {
 
     @Override
     public String getUpdatedDescription() {
-        return this.DESCRIPTIONS[0];
+        return this.DESCRIPTIONS[0]
+                + DESCRIPTIONS[1]
+                + DESCRIPTIONS[2]
+                + this.NUM_CARDS_FOR_OVERLOAD
+                + DESCRIPTIONS[3]
+                + DESCRIPTIONS[4]
+                + DESCRIPTIONS[5]
+                + this.MAX_SAFE_ENERGY
+                + DESCRIPTIONS[6];
     }
 
     @Override
@@ -274,9 +282,16 @@ public class CrackedAetherheartRelic_Warforged extends AbstractWarforgedRelic {
         this.actionManager().addCardQueueItem(cardQueueItem, true);
     }
 
+    /**
+     * Ensure that the character is using the custom energy manager meant for the Warforged, and set its energy
+     * gained per turn to 0 as the relic intends. I allowed the default to be 3 just in case the Warforged was ever
+     * played without this relic for some reason.
+     */
     private void ensureCustomEnergyManager() {
         if (!(this.player().energy instanceof EnergyManager_Warforged)) {
             this.player().energy = new EnergyManager_Warforged(EnergyPanel.getCurrentEnergy());
         }
+        this.player().energy.energyMaster = 0;
+        this.player().energy.energy = 0;
     }
 }

--- a/src/main/resources/thewarforged/localization/eng/RelicStrings.json
+++ b/src/main/resources/thewarforged/localization/eng/RelicStrings.json
@@ -10,7 +10,13 @@
     "NAME": "Cracked Aetherheart",
     "FLAVOR": "The soul of an automaton, damaged from the lightning of an aetherstorm.\nGenerates energy uncontrollably.",
     "DESCRIPTIONS": [
-      "Gain [E] whenever you play any card."
+      "#yLiving #yConstruct: Energy is now conserved between turns. You gain no energy at the start of your turn.",
+      " NL #yVolatile #yAether: Gain [E] whenever you play any card.",
+      " NL #yOverload: Every ",
+      "th card played is played twice and the number of [E] gained per card played is doubled (resets each turn).",
+      " NL The copy does not trigger effects from this relic.",
+      " NL #yAetherburn: After playing a card, lose HP for each [E] past ",
+      "."
     ]
   }
 }

--- a/src/main/resources/thewarforged/localization/eng/RelicStrings.json
+++ b/src/main/resources/thewarforged/localization/eng/RelicStrings.json
@@ -5,5 +5,12 @@
     "DESCRIPTIONS": [
       "Gain [E] at the start of your turn. [E] is an energy icon."
     ]
+  },
+  "${modID}:CrackedAetherheartRelic_Warforged": {
+    "NAME": "Cracked Aetherheart",
+    "FLAVOR": "The soul of an automaton, damaged from the lightning of an aetherstorm.\nGenerates energy uncontrollably.",
+    "DESCRIPTIONS": [
+      "Gain [E] whenever you play any card."
+    ]
   }
 }


### PR DESCRIPTION
The primary relic of the Warforged (Cracked Aetherheart), which controls all of the core mechanics of the character, has been built with only a few very minor bugs that should be fixed separately.

I also plan to separate the energy-based Dex/Str mechanic from the Cracked Aetherheart into a second starting relic, and this is the relic that will be replaced with an upgraded Boss version down the road.