### PR TITLE
Feature/livingconstruct relic into dev

### DIFF
--- a/src/main/java/thewarforged/character/TheWarforged.java
+++ b/src/main/java/thewarforged/character/TheWarforged.java
@@ -25,6 +25,7 @@ import thewarforged.cards.skillCards.RaiseShields_Warforged;
 import thewarforged.core.EnergyManager_Warforged;
 import thewarforged.relics.starterRelics.BiocircuitryRelic_Warforged;
 import thewarforged.relics.starterRelics.CrackedAetherheartRelic_Warforged;
+import thewarforged.relics.starterRelics.LivingConstructRelic_Warforged;
 
 import java.util.ArrayList;
 
@@ -156,8 +157,10 @@ public class TheWarforged extends CustomPlayer {
     @Override
     public ArrayList<String> getStartingRelics() {
         ArrayList<String> retVal = new ArrayList<>();
-        //IDs of starting relics. You can have multiple, but one is recommended.
-        retVal.add(CrackedAetherheartRelic_Warforged.ID);
+        //Add the IDs of each starting relic. This character changes how the game is played pretty drastically,
+        // so 3 starting relics were needed to get all the mechanics into readable, easy-to-digest segments.
+        retVal.add(LivingConstructRelic_Warforged.ID);
+        retVal.add(CrackedAetherheartRelic_Warforged.ID); //Examine text still too long! I need it to scroll...
         retVal.add(BiocircuitryRelic_Warforged.ID);
 
         return retVal;

--- a/src/main/java/thewarforged/core/EnergyManager_Warforged.java
+++ b/src/main/java/thewarforged/core/EnergyManager_Warforged.java
@@ -7,69 +7,57 @@ import com.megacrit.cardcrawl.core.EnergyManager;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
 import com.megacrit.cardcrawl.ui.panels.EnergyPanel;
-import thewarforged.relics.starterRelics.CrackedAetherheartRelic_Warforged;
-import thewarforged.util.GeneralUtils;
+import thewarforged.relics.starterRelics.LivingConstructRelic_Warforged;
 
 public class EnergyManager_Warforged extends EnergyManager {
 
-    AbstractPlayer _player;
-    CrackedAetherheartRelic_Warforged _crackedAetherheartRelic;
-    GameActionManager _actionManager;
+    private static LivingConstructRelic_Warforged _livingConstructRelic;
+
+    private static AbstractPlayer player() {
+        return AbstractDungeon.player;
+    }
+
+    private static GameActionManager actionManager() {
+        return AbstractDungeon.actionManager;
+    }
 
     public EnergyManager_Warforged(int energy) {
         super(energy);
     }
 
-    private AbstractPlayer player() {
-        if (this._player == null) this._player = AbstractDungeon.player;
-        return this._player;
-    }
-
-    private CrackedAetherheartRelic_Warforged crackedAetherheartRelic() {
-        if (this._crackedAetherheartRelic == null) {
-            AbstractRelic tmp = this.player().getRelic(CrackedAetherheartRelic_Warforged.ID);
-            if (tmp instanceof CrackedAetherheartRelic_Warforged) {
-                this._crackedAetherheartRelic = (CrackedAetherheartRelic_Warforged) tmp;
+    private static LivingConstructRelic_Warforged livingConstructRelic() {
+        if (_livingConstructRelic == null) {
+            AbstractRelic tmp = player().getRelic(LivingConstructRelic_Warforged.ID);
+            if (tmp instanceof LivingConstructRelic_Warforged) {
+                _livingConstructRelic = (LivingConstructRelic_Warforged) tmp;
             } else {
-                this._crackedAetherheartRelic = null;
+                _livingConstructRelic = null;
             }
         }
-        return this._crackedAetherheartRelic;
-    }
-
-    private GameActionManager actionManager() {
-        if (this._actionManager == null) this._actionManager = AbstractDungeon.actionManager;
-        return this._actionManager;
+        return _livingConstructRelic;
     }
 
     /**
      * Rather than patch the base class's recharge method, we override it to either work exactly like normal (if
-     * the character doesn't have the Cracked Aetherheart relic for some reason) or to simulate the same interaction
+     * the character doesn't have the Living Construct relic for some reason) or to simulate the same interaction
      * it would normally have with Ice Cream, since this relic has the same effect.
      */
     @Override
     public void recharge() {
-        GeneralUtils.easyPrint("1 ---- " + EnergyPanel.totalCount);
-        //If the character has the Cracked Aetherheart relic,
-        if (this.crackedAetherheartRelic() != null) {
-            GeneralUtils.easyPrint("2 ---- " + EnergyPanel.totalCount);
+        //If the character has the Living Construct relic,
+        if (livingConstructRelic() != null) {
             // then treat them the same as if they had the Ice Cream relic.
             if (EnergyPanel.totalCount > 0) {
-                GeneralUtils.easyPrint("3 ---- " + EnergyPanel.totalCount);
-                this.crackedAetherheartRelic().flash();
+                livingConstructRelic().flash();
                 RelicAboveCreatureAction relicAboveCreatureAction =
-                        new RelicAboveCreatureAction(this.player(), this.crackedAetherheartRelic());
-                this.actionManager().addToTop(relicAboveCreatureAction);
-                GeneralUtils.easyPrint("4 ---- " + EnergyPanel.totalCount);
+                        new RelicAboveCreatureAction(player(), livingConstructRelic());
+                actionManager().addToTop(relicAboveCreatureAction);
             }
-            GeneralUtils.easyPrint("5 ---- " + EnergyPanel.totalCount);
             //This should be adding zero, unless the character's core design has changed.
             EnergyPanel.addEnergy(this.energy);
-            GeneralUtils.easyPrint("6 ---- " + EnergyPanel.totalCount);
-            this.actionManager().updateEnergyGain(this.energy);
-            GeneralUtils.easyPrint("7 ---- " + EnergyPanel.totalCount);
+            actionManager().updateEnergyGain(this.energy);
         } else {
-            //Character did not have the Cracked Aetherheart relic. Just call the super's recharge like normal.
+            //Character did not have the Living Construct relic. Just call the super's recharge like normal.
             super.recharge();
         }
 

--- a/src/main/java/thewarforged/relics/starterRelics/CrackedAetherheartRelic_Warforged.java
+++ b/src/main/java/thewarforged/relics/starterRelics/CrackedAetherheartRelic_Warforged.java
@@ -11,7 +11,6 @@ import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.ui.panels.EnergyPanel;
 import thewarforged.actions.utilactions.GainEnergyAction_Warforged;
-import thewarforged.core.EnergyManager_Warforged;
 import thewarforged.relics.AbstractWarforgedRelic;
 import thewarforged.util.CardStats;
 
@@ -35,31 +34,24 @@ public class CrackedAetherheartRelic_Warforged extends AbstractWarforgedRelic {
     private final int OVERLOAD_ENERGY_GAIN_MULTIPLIER = 2;
     private int currentEnergyGain = STARTING_ENERGY_GAIN;
 
+    private GameActionManager actionManager() {
+        return AbstractDungeon.actionManager;
+    }
+
     public CrackedAetherheartRelic_Warforged() {
         //The second argument, NAME, is the name of both this relic and the image for this relic.
         super(ID, NAME, RARITY, LANDING_SOUND);
     }
 
-    private GameActionManager actionManager() {
-        return AbstractDungeon.actionManager;
-    }
-
     @Override
     public String getUpdatedDescription() {
         return this.DESCRIPTIONS[0]
-                + DESCRIPTIONS[1]
-                + DESCRIPTIONS[2]
+                + this.DESCRIPTIONS[1]
                 + this.NUM_CARDS_FOR_OVERLOAD
-                + DESCRIPTIONS[3]
-                + DESCRIPTIONS[4]
-                + DESCRIPTIONS[5]
+                + this.DESCRIPTIONS[2]
+                + this.DESCRIPTIONS[3]
                 + this.MAX_SAFE_ENERGY
-                + DESCRIPTIONS[6];
-    }
-
-    @Override
-    public void atPreBattle() {
-        this.ensureCustomEnergyManager();
+                + this.DESCRIPTIONS[4];
     }
 
     @Override
@@ -173,18 +165,5 @@ public class CrackedAetherheartRelic_Warforged extends AbstractWarforgedRelic {
         targetCard.purgeOnUse = true;
         CardQueueItem cardQueueItem = new CardQueueItem(tempCard, monster, targetCard.energyOnUse, true, true);
         this.actionManager().addCardQueueItem(cardQueueItem, true);
-    }
-
-    /**
-     * Ensure that the character is using the custom energy manager meant for the Warforged, and set its energy
-     * gained per turn to 0 as the relic intends. I allowed the default to be 3 just in case the Warforged was ever
-     * played without this relic for some reason.
-     */
-    private void ensureCustomEnergyManager() {
-        if (!(this.player().energy instanceof EnergyManager_Warforged)) {
-            this.player().energy = new EnergyManager_Warforged(EnergyPanel.getCurrentEnergy());
-        }
-        this.player().energy.energyMaster = 0;
-        this.player().energy.energy = 0;
     }
 }

--- a/src/main/java/thewarforged/relics/starterRelics/LivingConstructRelic_Warforged.java
+++ b/src/main/java/thewarforged/relics/starterRelics/LivingConstructRelic_Warforged.java
@@ -1,0 +1,46 @@
+package thewarforged.relics.starterRelics;
+
+import com.megacrit.cardcrawl.ui.panels.EnergyPanel;
+import thewarforged.core.EnergyManager_Warforged;
+import thewarforged.relics.AbstractWarforgedRelic;
+
+import static thewarforged.TheWarforgedMod.makeID;
+
+public class LivingConstructRelic_Warforged extends AbstractWarforgedRelic  {
+    private static final String NAME = LivingConstructRelic_Warforged.class.getSimpleName();
+    public static final String ID = makeID(NAME);
+    private static final RelicTier RARITY = RelicTier.STARTER;
+    private static final LandingSound LANDING_SOUND = LandingSound.CLINK;
+
+    public LivingConstructRelic_Warforged() {
+        super(ID, NAME, RARITY, LANDING_SOUND);
+    }
+
+    @Override
+    public String getUpdatedDescription() {
+        return this.DESCRIPTIONS[0];
+    }
+
+    @Override
+    public void atPreBattle() {
+        this.ensureCustomEnergyManager();
+        this.setEnergyPerTurn();
+    }
+
+    /**
+     * Ensure that the character is using the custom energy manager meant for the Warforged.
+     * I allowed the default to be 3 just in case the Warforged was ever played without this relic
+     * for some reason.
+     */
+    private void ensureCustomEnergyManager() {
+        //The custom energy manager is required
+        if (!(this.player().energy instanceof EnergyManager_Warforged)) {
+            this.player().energy = new EnergyManager_Warforged(EnergyPanel.getCurrentEnergy());
+        }
+    }
+
+    private void setEnergyPerTurn() {
+        this.player().energy.energyMaster = 0;
+        this.player().energy.energy = 0;
+    }
+}

--- a/src/main/resources/thewarforged/localization/eng/RelicStrings.json
+++ b/src/main/resources/thewarforged/localization/eng/RelicStrings.json
@@ -6,19 +6,6 @@
       "Gain [E] at the start of your turn. [E] is an energy icon."
     ]
   },
-  "${modID}:CrackedAetherheartRelic_Warforged": {
-    "NAME": "Cracked Aetherheart",
-    "FLAVOR": "The soul of an automaton, damaged from the lightning of an aetherstorm.\nGenerates energy uncontrollably.",
-    "DESCRIPTIONS": [
-      "#yLiving #yConstruct: Energy is now conserved between turns. You gain no energy at the start of your turn.",
-      " NL #yVolatile #yAether: Gain [E] whenever you play any card.",
-      " NL #yOverload: Every ",
-      "th card played is played twice and the number of [E] gained per card played is doubled (resets each turn).",
-      " NL The copy does not trigger effects from this relic.",
-      " NL #yAetherburn: After playing a card, lose HP for each [E] past ",
-      "."
-    ]
-  },
   "${modID}:BiocircuitryRelic_Warforged": {
     "NAME": "Biocircuitry",
     "FLAVOR": "The mechanism by which the Aetherheart powers the body. Doubles as a nervous system.\nSensitive to power fluctuations.",
@@ -28,6 +15,24 @@
       " #yStrength.",
       " NL #yPower #yFluctuations: For every ",
       " [E] you have above 0, you have -1 #yDexterity and +1 #yStrength."
+    ]
+  },
+  "${modID}:CrackedAetherheartRelic_Warforged": {
+    "NAME": "Cracked Aetherheart",
+    "FLAVOR": "The soul of an automaton, damaged from the lightning of an aetherstorm.\nGenerates energy uncontrollably.",
+    "DESCRIPTIONS": [
+      "#yVolatile #yAether: Gain [E] whenever you play any card. This doubles every time a card is overloaded that turn",
+      " NL #yOverload: Every ",
+      "th card played is played twice.",
+      " NL #yAetherburn: After playing a card, lose HP for each [E] past ",
+      "."
+    ]
+  },
+  "${modID}:LivingConstructRelic_Warforged": {
+    "NAME": "Living Construct",
+    "FLAVOR": "Because they hated violence, the ancients created war machines, with souls and memory long enough to learn to hate it themselves.",
+    "DESCRIPTIONS": [
+      "Energy is now conserved between turns. NL You gain no energy at the start of your turn."
     ]
   }
 }


### PR DESCRIPTION
The third and final starter relic (although the first in the list shown in game) is done. The mechanic behind the character gaining/losing no energy between turns has been successfully moved from the Cracked Aetherheart relic to the Living Construct relic.

This did manage to spread out the language a bit for the relics' mechanics, but the Cracked Aetherheart is still a bit too long in the examine view. I don't think there is anything I can do about that without adding a scroll wheel or something to the description section of the examine view. At least it looks fine in the mouseover tooltip in-game where most people will see it.