### PR TITLE
Feature/more replacement part cards into dev

### DIFF
--- a/src/main/java/thewarforged/actions/powerActions/ApplyIonizedPowerAction_Warforged.java
+++ b/src/main/java/thewarforged/actions/powerActions/ApplyIonizedPowerAction_Warforged.java
@@ -1,0 +1,39 @@
+package thewarforged.actions.powerActions;
+
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+import thewarforged.powers.IonCoilPower_Warforged;
+import thewarforged.powers.IonizedPower_Warforged;
+
+public class ApplyIonizedPowerAction_Warforged extends AbstractGameAction {
+    private final AbstractCreature TARGET_CREATURE;
+    private final AbstractCreature SOURCE;
+    private final int IONIZED_AMOUNT;
+
+    public ApplyIonizedPowerAction_Warforged(AbstractCreature targetCreature, AbstractCreature source, int ionizedAmount) {
+        this.TARGET_CREATURE = targetCreature;
+        this.SOURCE = source;
+        this.IONIZED_AMOUNT = ionizedAmount;
+    }
+
+    @Override
+    public void update() {
+        //Adjust the amount of Ionized applied based on the "amount" on the owner's IonCoilPower, if applicable.
+        int adjustedNumIonized = this.IONIZED_AMOUNT;
+        AbstractPower ionCoilPowerWarforged = this.SOURCE.getPower(IonCoilPower_Warforged.POWER_ID);
+        if (ionCoilPowerWarforged instanceof IonCoilPower_Warforged) {
+            adjustedNumIonized += ionCoilPowerWarforged.amount;
+        }
+
+        //Then apply the Ionized to the target. Add the action to the top, since this action is meant to be a stand-in
+        // for applying Ionized normally, just with extra logic. We don't want it taking longer than necessary to be
+        // applied just because there was extra logic to it.
+        IonizedPower_Warforged ionizedPower =
+                new IonizedPower_Warforged(this.TARGET_CREATURE, this.SOURCE, adjustedNumIonized);
+        this.addToTop(new ApplyPowerAction(this.TARGET_CREATURE, this.SOURCE, ionizedPower, adjustedNumIonized));
+
+        this.isDone = true;
+    }
+}

--- a/src/main/java/thewarforged/cards/attackCards/DirectCurrent_Warforged.java
+++ b/src/main/java/thewarforged/cards/attackCards/DirectCurrent_Warforged.java
@@ -1,14 +1,13 @@
 package thewarforged.cards.attackCards;
 
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
-import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.actions.common.DamageAction;
 import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import thewarforged.actions.powerActions.ApplyIonizedPowerAction_Warforged;
 import thewarforged.cards.AbstractWarforgedCard;
 import thewarforged.character.TheWarforged;
-import thewarforged.powers.IonizedPower_Warforged;
 import thewarforged.util.CardStats;
 
 public class DirectCurrent_Warforged extends AbstractWarforgedCard {
@@ -50,7 +49,9 @@ public class DirectCurrent_Warforged extends AbstractWarforgedCard {
                 AbstractGameAction.AttackEffect.LIGHTNING
         );
         this.addToBot(damageAction);
-        IonizedPower_Warforged ionizedPower = new IonizedPower_Warforged(monster, this.magicNumber);
-        this.addToBot(new ApplyPowerAction(monster, player, ionizedPower, this.magicNumber));
+
+        this.addToBot(new ApplyIonizedPowerAction_Warforged(monster, player, this.magicNumber));
+//        IonizedPower_Warforged ionizedPower = new IonizedPower_Warforged(monster, this.magicNumber);
+//        this.addToBot(new ApplyPowerAction(monster, player, ionizedPower, this.magicNumber));
     }
 }

--- a/src/main/java/thewarforged/cards/powerCards/FluxNode_Warforged.java
+++ b/src/main/java/thewarforged/cards/powerCards/FluxNode_Warforged.java
@@ -1,0 +1,56 @@
+package thewarforged.cards.powerCards;
+
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import thewarforged.cards.AbstractWarforgedCard;
+import thewarforged.character.TheWarforged;
+import thewarforged.powers.FluxPower_Warforged;
+import thewarforged.util.CardStats;
+
+/**
+ * This class is for a power card that represents a missing/broken part for the Warforged, the Flux Node.
+ * Once played, any card played after with a cost of 4 or higher (variable) gains 3 (variable) temporary Dexterity.
+ * Upgraded, the threshold decreases by 1, and the temp Dex increases by 1.
+ * For the purposes of this effect, cards that cost X are considered to cost the player's total energy spent on
+ * the card, which would be their current total at the time the X-cost card is played + the amount of energy granted
+ * by the CrackedAetherheart for each card played, which varies.
+ */
+public class FluxNode_Warforged extends AbstractWarforgedCard {
+    public static final String ID = makeID(FluxNode_Warforged.class.getSimpleName());
+
+    private static final CardStats info = new CardStats(
+            TheWarforged.Meta.CARD_COLOR,
+            CardType.POWER,
+            CardRarity.UNCOMMON,
+            CardTarget.SELF,
+            CardStats.POSITIVE_COST(4)
+    );
+
+    //The amount of energy that a card must cost/use in order to trigger the effect.
+    private static final int ENERGY_COST_TO_ACTIVATE = 4;
+    private static final int UPGRADED_ENERGY_COST_TO_ACTIVATE_INCREASE = -1;
+
+    //The amount of temporary Dexterity that will be gained by this power when triggered.
+    private static final int DEX_GAINED = 3;
+    private static final int UPGRADED_DEX_GAINED_INCREASE = 1;
+    private static final String CUSTOM_VAR_NAME = "DEX_GAIN";
+
+    public FluxNode_Warforged() {
+        super(ID, info);
+        this.isReplacementCard = true;
+
+        setMagic(ENERGY_COST_TO_ACTIVATE, UPGRADED_ENERGY_COST_TO_ACTIVATE_INCREASE);
+        setCustomVar(CUSTOM_VAR_NAME, DEX_GAINED, UPGRADED_DEX_GAINED_INCREASE);
+    }
+
+    @Override
+    public void use(AbstractPlayer player, AbstractMonster monster) {
+        FluxPower_Warforged fluxPower = new FluxPower_Warforged(
+                player,
+                this.magicNumber,
+                this.customVar(CUSTOM_VAR_NAME)
+        );
+        this.addToBot(new ApplyPowerAction(player, player, fluxPower));
+    }
+}

--- a/src/main/java/thewarforged/cards/powerCards/Gyrospine_Warforged.java
+++ b/src/main/java/thewarforged/cards/powerCards/Gyrospine_Warforged.java
@@ -13,9 +13,6 @@ import thewarforged.util.CardStats;
 public class Gyrospine_Warforged extends AbstractWarforgedCard {
     public static final String ID = makeID(Gyrospine_Warforged.class.getSimpleName());
 
-    private final int REGEN_ON_TRIGGER = 4;
-    private final int UPGRADED_REGEN_ON_TRIGGER_INCREASE = 0;
-
     private static final CardStats info = new CardStats(
             TheWarforged.Meta.CARD_COLOR,
             CardType.POWER,
@@ -23,6 +20,9 @@ public class Gyrospine_Warforged extends AbstractWarforgedCard {
             CardTarget.SELF,
             CardStats.POSITIVE_COST(2)
     );
+
+    private final int REGEN_ON_TRIGGER = 4;
+    private final int UPGRADED_REGEN_ON_TRIGGER_INCREASE = 0;
 
     public Gyrospine_Warforged() {
         super(ID, info);
@@ -33,14 +33,9 @@ public class Gyrospine_Warforged extends AbstractWarforgedCard {
 
     @Override
     public void use(AbstractPlayer player, AbstractMonster monster) {
-        for(AbstractPower pow : player.powers) {
-            if (pow.ID.equals(GyrospinePower_Warforged.POWER_ID)) {
-                return;
-            }
-        }
+        if (player.getPower(GyrospinePower_Warforged.POWER_ID) != null) return;
 
-        this.addToBot(
-                new ApplyPowerAction(
+        this.addToBot(new ApplyPowerAction(
                         player,
                         player,
                         new GyrospinePower_Warforged(player, this.magicNumber)));

--- a/src/main/java/thewarforged/cards/powerCards/Gyrospine_Warforged.java
+++ b/src/main/java/thewarforged/cards/powerCards/Gyrospine_Warforged.java
@@ -3,7 +3,6 @@ package thewarforged.cards.powerCards;
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
-import com.megacrit.cardcrawl.powers.AbstractPower;
 import thewarforged.cards.AbstractWarforgedCard;
 import thewarforged.character.TheWarforged;
 import thewarforged.powers.GyrospinePower_Warforged;

--- a/src/main/java/thewarforged/cards/powerCards/IonCoil_Warforged.java
+++ b/src/main/java/thewarforged/cards/powerCards/IonCoil_Warforged.java
@@ -1,0 +1,54 @@
+package thewarforged.cards.powerCards;
+
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import thewarforged.cards.AbstractWarforgedCard;
+import thewarforged.character.TheWarforged;
+import thewarforged.powers.HighVoltagePower_Warforged;
+import thewarforged.powers.IonCoilPower_Warforged;
+import thewarforged.util.CardStats;
+
+public class IonCoil_Warforged extends AbstractWarforgedCard {
+    public static final String ID = makeID(IonCoil_Warforged.class.getSimpleName());
+
+    private static final CardStats info = new CardStats(
+            TheWarforged.Meta.CARD_COLOR,
+            CardType.POWER,
+            CardRarity.UNCOMMON,
+            CardTarget.SELF,
+            CardStats.POSITIVE_COST(2)
+    );
+
+    private static final int ADDITIONAL_IONIZED = 1;
+    private static final int UPGRADED_ADDITIONAL_IONIZED_INCREASE = 0;
+
+    private static final int HP_LOSS_PER_IONIZED = 0;
+    private static final int UPGRADED_HP_LOSS_PER_IONIZED_INCREASE = 3;
+    private static final String HP_LOSS_VAR = "HP_LOSS_VAR";
+
+    public IonCoil_Warforged() {
+        super(ID, info);
+
+        setMagic(ADDITIONAL_IONIZED, UPGRADED_ADDITIONAL_IONIZED_INCREASE);
+        setCustomVar(HP_LOSS_VAR, HP_LOSS_PER_IONIZED, UPGRADED_HP_LOSS_PER_IONIZED_INCREASE);
+    }
+
+    @Override
+    public void use(AbstractPlayer player, AbstractMonster monster) {
+        IonCoilPower_Warforged ionCoilPower = new IonCoilPower_Warforged(
+                player,
+                this.magicNumber
+        );
+        this.addToBot(new ApplyPowerAction(player, player, ionCoilPower, this.magicNumber));
+
+        if (this.upgraded) {
+            int hpLossVar = this.customVar(HP_LOSS_VAR);
+            HighVoltagePower_Warforged highVoltagePower = new HighVoltagePower_Warforged(
+                    player,
+                    hpLossVar
+            );
+            this.addToBot(new ApplyPowerAction(player, player, highVoltagePower, hpLossVar));
+        }
+    }
+}

--- a/src/main/java/thewarforged/cards/powerCards/Neurolink_Warforged.java
+++ b/src/main/java/thewarforged/cards/powerCards/Neurolink_Warforged.java
@@ -1,0 +1,42 @@
+package thewarforged.cards.powerCards;
+
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import thewarforged.cards.AbstractWarforgedCard;
+import thewarforged.character.TheWarforged;
+import thewarforged.powers.NeurolinkPower_Warforged;
+import thewarforged.util.CardStats;
+
+public class Neurolink_Warforged extends AbstractWarforgedCard {
+    public static final String ID = makeID(Neurolink_Warforged.class.getSimpleName());
+
+    private static final CardStats info = new CardStats(
+            TheWarforged.Meta.CARD_COLOR,
+            CardType.POWER,
+            CardRarity.RARE,
+            CardTarget.SELF,
+            CardStats.POSITIVE_COST(4)
+    );
+
+    //The amount of Energy Shield that will be gained when attacking an attacking enemy.
+    private static final int ENERGY_SHIELD_GAIN = 3;
+    //How much the above number increases on upgrade.
+    private static final int UPGRADED_ENERGY_SHIELD_GAIN_INCREASE = 2;
+
+    public Neurolink_Warforged() {
+        super(ID, info);
+        this.isReplacementCard = true;
+
+        setMagic(ENERGY_SHIELD_GAIN, UPGRADED_ENERGY_SHIELD_GAIN_INCREASE);
+    }
+
+    @Override
+    public void use(AbstractPlayer player, AbstractMonster monster) {
+        this.addToBot(new ApplyPowerAction(
+                player,
+                player,
+                new NeurolinkPower_Warforged(this.magicNumber),
+                this.magicNumber));
+    }
+}

--- a/src/main/java/thewarforged/cards/powerCards/VeryParticularScrew_Warforged.java
+++ b/src/main/java/thewarforged/cards/powerCards/VeryParticularScrew_Warforged.java
@@ -1,0 +1,39 @@
+package thewarforged.cards.powerCards;
+
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.powers.MetallicizePower;
+import thewarforged.cards.AbstractWarforgedCard;
+import thewarforged.character.TheWarforged;
+import thewarforged.util.CardStats;
+
+public class VeryParticularScrew_Warforged extends AbstractWarforgedCard {
+    public static final String ID = makeID(VeryParticularScrew_Warforged.class.getSimpleName());
+
+    private static final CardStats info = new CardStats(
+            TheWarforged.Meta.CARD_COLOR,
+            CardType.POWER,
+            CardRarity.COMMON,
+            CardTarget.SELF,
+            CardStats.ZERO_COST()
+    );
+
+    private static final int METALLICIZE_AMOUNT = 2;
+    private static final int UPGRADED_METALLICIZE_AMOUNT_INCREASE = 1;
+
+    public VeryParticularScrew_Warforged() {
+        super(ID, info);
+        this.isReplacementCard = true;
+
+        setMagic(METALLICIZE_AMOUNT, UPGRADED_METALLICIZE_AMOUNT_INCREASE);
+    }
+
+    @Override
+    public void use(AbstractPlayer player, AbstractMonster monster) {
+        this.addToBot(new ApplyPowerAction(
+                player,
+                player,
+                new MetallicizePower(player, this.magicNumber)));
+    }
+}

--- a/src/main/java/thewarforged/cards/skillCards/StabilizeShields_Warforged.java
+++ b/src/main/java/thewarforged/cards/skillCards/StabilizeShields_Warforged.java
@@ -1,0 +1,45 @@
+package thewarforged.cards.skillCards;
+
+import com.evacipated.cardcrawl.mod.stslib.blockmods.BlockModifierManager;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.common.GainBlockAction;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import thewarforged.cards.AbstractWarforgedCard;
+import thewarforged.character.TheWarforged;
+import thewarforged.modifiers.EnergyShieldBlockModifier;
+import thewarforged.powers.StableShieldsPower_Warforged;
+import thewarforged.util.CardStats;
+
+public class StabilizeShields_Warforged extends AbstractWarforgedCard {
+    public static final String ID = makeID(StabilizeShields_Warforged.class.getSimpleName());
+
+    private static final CardStats info = new CardStats(
+            TheWarforged.Meta.CARD_COLOR,
+            CardType.SKILL,
+            CardRarity.UNCOMMON,
+            CardTarget.SELF,
+            CardStats.ZERO_COST()
+    );
+
+    private static final int ENERGY_SHIELD_AMOUNT = 6;
+    private static final int UPGRADED_ENERGY_SHIELD_AMOUNT_INCREASE = 3;
+    private static final int NUM_STABILIZE_SHIELDS_POWER = 1;
+
+    public StabilizeShields_Warforged() {
+        super(ID, info);
+
+        setBlock(ENERGY_SHIELD_AMOUNT, UPGRADED_ENERGY_SHIELD_AMOUNT_INCREASE);
+
+        BlockModifierManager.addModifier(this, new EnergyShieldBlockModifier());
+    }
+
+    @Override
+    public void use(AbstractPlayer player, AbstractMonster monster) {
+        this.addToBot(new GainBlockAction(player, player, this.block));
+        this.addToBot(new ApplyPowerAction(
+                player,
+                player,
+                new StableShieldsPower_Warforged(player, NUM_STABILIZE_SHIELDS_POWER)));
+    }
+}

--- a/src/main/java/thewarforged/modifiers/EnergyShieldBlockModifier.java
+++ b/src/main/java/thewarforged/modifiers/EnergyShieldBlockModifier.java
@@ -5,6 +5,7 @@ import com.evacipated.cardcrawl.mod.stslib.blockmods.AbstractBlockModifier;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.localization.CardStrings;
 import com.megacrit.cardcrawl.localization.KeywordStrings;
+import thewarforged.powers.StableShieldsPower_Warforged;
 
 import static thewarforged.TheWarforgedMod.makeID;
 
@@ -20,6 +21,7 @@ public class EnergyShieldBlockModifier extends AbstractBlockModifier {
 
     @Override
     public int amountLostAtStartOfTurn() {
+        if (this.owner.getPower(StableShieldsPower_Warforged.POWER_ID) != null) return 0;
         return ((this.getCurrentAmount() + 1) / 2);
     }
 

--- a/src/main/java/thewarforged/powers/FluxPower_Warforged.java
+++ b/src/main/java/thewarforged/powers/FluxPower_Warforged.java
@@ -1,0 +1,78 @@
+package thewarforged.powers;
+
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.utility.UseCardAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+import com.megacrit.cardcrawl.powers.DexterityPower;
+import com.megacrit.cardcrawl.powers.LoseDexterityPower;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+import com.megacrit.cardcrawl.ui.panels.EnergyPanel;
+import thewarforged.relics.starterRelics.CrackedAetherheartRelic_Warforged;
+import thewarforged.util.CardStats;
+
+import static thewarforged.TheWarforgedMod.makeID;
+
+public class FluxPower_Warforged extends AbstractWarforgedPower {
+    public static final String POWER_ID = makeID(FluxPower_Warforged.class.getSimpleName());
+    private static final AbstractPower.PowerType POWER_TYPE = PowerType.BUFF;
+    private static final boolean IS_TURNED_BASED = false;
+
+    private static CrackedAetherheartRelic_Warforged _aetherheartRelic;
+
+    /**
+     * Constructor.
+     * @param owner Must be the player, or this power will break
+     * @param energyToTrigger The amount of energy a card must cost/use in order to trigger the effect
+     * @param tempDexOnTrigger The amount of temporary Dexterity gained when triggered
+     */
+    public FluxPower_Warforged(AbstractCreature owner, int energyToTrigger, int tempDexOnTrigger) {
+        super(POWER_ID, POWER_TYPE, IS_TURNED_BASED, owner, energyToTrigger);
+        this.amount2 = tempDexOnTrigger;
+    }
+
+    private static CrackedAetherheartRelic_Warforged get_aetherheartRelic() {
+        if (_aetherheartRelic == null) {
+            AbstractRelic relic = AbstractDungeon.player.getRelic(CrackedAetherheartRelic_Warforged.ID);
+            _aetherheartRelic = (CrackedAetherheartRelic_Warforged) relic;
+        }
+        return _aetherheartRelic;
+    }
+
+    private static AbstractPlayer getPlayer() { return AbstractDungeon.player; }
+
+    @Override
+    public void updateDescription() {
+        this.description = this.DESCRIPTIONS[0]
+                + this.amount
+                + this.DESCRIPTIONS[1]
+                + this.amount2
+                + this.DESCRIPTIONS[2];
+    }
+
+    @Override
+    public void onUseCard(AbstractCard card, UseCardAction action){
+        int cost = card.cost;
+        if (cost == CardStats.X_COST()) {
+            cost = EnergyPanel.getCurrentEnergy() + get_aetherheartRelic().getCurrentEnergyGain();
+        }
+        if (cost >= this.amount) {
+            AbstractPlayer player = getPlayer();
+
+            DexterityPower gainDexPower = new DexterityPower(player, this.amount2);
+            ApplyPowerAction positivePowerAction =
+                    new ApplyPowerAction(player, player, gainDexPower, this.amount2);
+            this.addToBot(positivePowerAction);
+
+            LoseDexterityPower loseDexterityPower = new LoseDexterityPower(player, this.amount2);
+            ApplyPowerAction negativePowerAction =
+                    new ApplyPowerAction(player, player, loseDexterityPower, this.amount2);
+            this.addToBot(negativePowerAction);
+
+            this.flash();
+        }
+    }
+}

--- a/src/main/java/thewarforged/powers/HighVoltagePower_Warforged.java
+++ b/src/main/java/thewarforged/powers/HighVoltagePower_Warforged.java
@@ -1,0 +1,23 @@
+package thewarforged.powers;
+
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+
+import static thewarforged.TheWarforgedMod.makeID;
+
+public class HighVoltagePower_Warforged extends AbstractWarforgedPower {
+    public static final String POWER_ID = makeID(HighVoltagePower_Warforged.class.getSimpleName());
+    private static final AbstractPower.PowerType POWER_TYPE = PowerType.BUFF;
+    private static final boolean IS_TURNED_BASED = false;
+
+    public HighVoltagePower_Warforged(AbstractCreature owner, int hpLossPerIonized) {
+        super(POWER_ID, POWER_TYPE, IS_TURNED_BASED, owner, hpLossPerIonized);
+    }
+
+    @Override
+    public void updateDescription() {
+        this.description = this.DESCRIPTIONS[0]
+                + this.amount
+                + this.DESCRIPTIONS[1];
+    }
+}

--- a/src/main/java/thewarforged/powers/IonCoilPower_Warforged.java
+++ b/src/main/java/thewarforged/powers/IonCoilPower_Warforged.java
@@ -1,0 +1,29 @@
+package thewarforged.powers;
+
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+
+import static thewarforged.TheWarforgedMod.makeID;
+
+public class IonCoilPower_Warforged extends AbstractWarforgedPower {
+    public static final String POWER_ID = makeID(IonCoilPower_Warforged.class.getSimpleName());
+    private static final AbstractPower.PowerType POWER_TYPE = PowerType.BUFF;
+    private static final boolean IS_TURNED_BASED = false;
+
+    /**
+     * Constructor.
+     * @param owner The creature to whom the power is applied
+     * @param additionalIonized The number of additional ionized to apply when the owner applies
+     *                          Ionizes to another creature
+     */
+    public IonCoilPower_Warforged(AbstractCreature owner, int additionalIonized) {
+        super(POWER_ID, POWER_TYPE, IS_TURNED_BASED, owner, additionalIonized);
+    }
+
+    @Override
+    public void updateDescription() {
+        this.description = this.DESCRIPTIONS[0]
+                + this.amount
+                + this.DESCRIPTIONS[1];
+    }
+}

--- a/src/main/java/thewarforged/powers/IonizedPower_Warforged.java
+++ b/src/main/java/thewarforged/powers/IonizedPower_Warforged.java
@@ -3,12 +3,14 @@ package thewarforged.powers;
 import com.badlogic.gdx.math.MathUtils;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.DamageAction;
+import com.megacrit.cardcrawl.actions.common.LoseHPAction;
 import com.megacrit.cardcrawl.actions.common.ReducePowerAction;
 import com.megacrit.cardcrawl.actions.common.RemoveSpecificPowerAction;
 import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.powers.AbstractPower;
+import thewarforged.util.WarforgedUtils;
 
 import static thewarforged.TheWarforgedMod.makeID;
 
@@ -17,8 +19,44 @@ public class IonizedPower_Warforged extends AbstractWarforgedPower {
     private static final AbstractPower.PowerType POWER_TYPE = PowerType.DEBUFF;
     private static final boolean IS_TURNED_BASED = false;
 
-    public IonizedPower_Warforged(AbstractCreature owner, int amount) {
+    public IonizedPower_Warforged(AbstractCreature owner, AbstractCreature source, int amount) {
         super(POWER_ID, POWER_TYPE, IS_TURNED_BASED, owner, amount);
+        this.source = source;
+    }
+
+    private void handleHighVoltage() {
+        AbstractPower sourceHighVoltagePower = this.source.getPower(HighVoltagePower_Warforged.POWER_ID);
+        if (sourceHighVoltagePower instanceof HighVoltagePower_Warforged) {
+            LoseHPAction loseHPAction = new LoseHPAction(
+                    this.owner,
+                    this.source,
+                    (sourceHighVoltagePower.amount * this.amount),
+                    AbstractGameAction.AttackEffect.LIGHTNING);
+            this.addToBot(loseHPAction);
+            sourceHighVoltagePower.flash();
+        }
+    }
+
+    /**
+     * This is called when the power is stacked, meaning the power already existed but has now been added onto
+     * (or removed from if the stackAmount is negative).
+     * @param stackAmount The change in amount for this power.
+     */
+    @Override
+    public void stackPower(int stackAmount) {
+        super.stackPower(stackAmount);
+        //As long as the amount was increased, handle the source's High Voltage power, is applicable.
+        if (stackAmount > 0) this.handleHighVoltage();
+    }
+
+    /**
+     * This runs AFTER the initial application. The amount that was applied will already be on
+     * the owner when this runs.
+     */
+    @Override
+    public void onInitialApplication() {
+        WarforgedUtils.easyPrint("onInitialApplication");
+        this.handleHighVoltage();
     }
 
     /**

--- a/src/main/java/thewarforged/powers/IonizedPower_Warforged.java
+++ b/src/main/java/thewarforged/powers/IonizedPower_Warforged.java
@@ -20,8 +20,7 @@ public class IonizedPower_Warforged extends AbstractWarforgedPower {
     private static final boolean IS_TURNED_BASED = false;
 
     public IonizedPower_Warforged(AbstractCreature owner, AbstractCreature source, int amount) {
-        super(POWER_ID, POWER_TYPE, IS_TURNED_BASED, owner, amount);
-        this.source = source;
+        super(POWER_ID, POWER_TYPE, IS_TURNED_BASED, owner, source, amount);
     }
 
     private void handleHighVoltage() {

--- a/src/main/java/thewarforged/powers/IonizedPower_Warforged.java
+++ b/src/main/java/thewarforged/powers/IonizedPower_Warforged.java
@@ -13,7 +13,7 @@ import com.megacrit.cardcrawl.powers.AbstractPower;
 import static thewarforged.TheWarforgedMod.makeID;
 
 public class IonizedPower_Warforged extends AbstractWarforgedPower {
-    public static final String POWER_ID = makeID("IonizedPower_Warforged");
+    public static final String POWER_ID = makeID(IonizedPower_Warforged.class.getSimpleName());
     private static final AbstractPower.PowerType POWER_TYPE = PowerType.DEBUFF;
     private static final boolean IS_TURNED_BASED = false;
 

--- a/src/main/java/thewarforged/powers/NeurolinkPower_Warforged.java
+++ b/src/main/java/thewarforged/powers/NeurolinkPower_Warforged.java
@@ -1,0 +1,59 @@
+package thewarforged.powers;
+
+import com.evacipated.cardcrawl.mod.stslib.actions.common.GainCustomBlockAction;
+import com.evacipated.cardcrawl.mod.stslib.blockmods.BlockModContainer;
+import com.megacrit.cardcrawl.cards.DamageInfo;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import thewarforged.modifiers.EnergyShieldBlockModifier;
+import thewarforged.util.WarforgedUtils;
+
+import static thewarforged.TheWarforgedMod.makeID;
+
+public class NeurolinkPower_Warforged extends AbstractWarforgedPower {
+    public static final String POWER_ID = makeID(NeurolinkPower_Warforged.class.getSimpleName());
+    private static final PowerType POWER_TYPE = PowerType.BUFF;
+    private static final boolean IS_TURNED_BASED = false;
+
+    private static BlockModContainer blockModContainer = null;
+
+    private static AbstractPlayer player() { return AbstractDungeon.player; }
+
+    public NeurolinkPower_Warforged(int amount) {
+        super(POWER_ID, POWER_TYPE, IS_TURNED_BASED, player(), amount);
+
+        EnergyShieldBlockModifier energyShieldBlock = new EnergyShieldBlockModifier();
+        blockModContainer = new BlockModContainer(this, energyShieldBlock);
+
+        this.updateDescription();
+    }
+
+    @Override
+    public void updateDescription() {
+        this.description = this.DESCRIPTIONS[0]
+            + this.amount
+            + this.DESCRIPTIONS[1];
+    }
+
+    /**
+     * Every time NORMAL damage is applied to a monster from the player, if that monster intents to attack,
+     * then the player receives Energy Shield.
+     * @param info Information on the damage being dealt to the target
+     * @param damageAmount The amount of damage being dealt to the target
+     * @param target The creature being attacked
+     */
+    @Override
+    public void onAttack(DamageInfo info, int damageAmount, AbstractCreature target) {
+        if (info.type != DamageInfo.DamageType.NORMAL || !(target instanceof AbstractMonster)) return;
+        //If the creature being attacked is a monster and that monster is attacking (or attacking & something),
+        if (WarforgedUtils.isMonsterAttacking((AbstractMonster) target)) {
+            // then we gain some Energy Shield.
+            GainCustomBlockAction blockAction =
+                    new GainCustomBlockAction(blockModContainer, player(), this.amount);
+            this.addToBot(blockAction);
+            this.flash();
+        }
+    }
+}

--- a/src/main/java/thewarforged/powers/StableShieldsPower_Warforged.java
+++ b/src/main/java/thewarforged/powers/StableShieldsPower_Warforged.java
@@ -1,0 +1,38 @@
+package thewarforged.powers;
+
+import com.megacrit.cardcrawl.actions.common.ReducePowerAction;
+import com.megacrit.cardcrawl.actions.common.RemoveSpecificPowerAction;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+
+import static thewarforged.TheWarforgedMod.makeID;
+
+public class StableShieldsPower_Warforged extends AbstractWarforgedPower {
+    public static final String POWER_ID = makeID(GyrospinePower_Warforged.class.getSimpleName());
+    private static final AbstractPower.PowerType POWER_TYPE = PowerType.BUFF;
+    private static final boolean IS_TURNED_BASED = true;
+
+    public StableShieldsPower_Warforged(AbstractCreature owner, int amount) {
+        super(POWER_ID, POWER_TYPE, IS_TURNED_BASED, owner, amount);
+        this.updateDescription();
+    }
+
+    @Override
+    public void updateDescription() {
+        if (this.amount == 1) {
+            this.description = DESCRIPTIONS[0];
+        } else {
+            this.description = DESCRIPTIONS[1] + this.amount + DESCRIPTIONS[2];
+        }
+    }
+
+    @Override
+    public void atEndOfRound() {
+        if (this.amount == 0) {
+            this.addToBot(new RemoveSpecificPowerAction(this.owner, this.owner, POWER_ID));
+        } else {
+            this.addToBot(new ReducePowerAction(this.owner, this.owner, POWER_ID, 1));
+        }
+
+    }
+}

--- a/src/main/java/thewarforged/relics/starterRelics/CrackedAetherheartRelic_Warforged.java
+++ b/src/main/java/thewarforged/relics/starterRelics/CrackedAetherheartRelic_Warforged.java
@@ -37,6 +37,10 @@ public class CrackedAetherheartRelic_Warforged extends AbstractWarforgedRelic {
         super(ID, NAME, RARITY, LANDING_SOUND);
     }
 
+    public int getCurrentEnergyGain() {
+        return this.currentEnergyGain;
+    }
+
     @Override
     public String getUpdatedDescription() {
         return this.DESCRIPTIONS[0];

--- a/src/main/java/thewarforged/relics/starterRelics/DiagnosticsRelic_Warforged.java
+++ b/src/main/java/thewarforged/relics/starterRelics/DiagnosticsRelic_Warforged.java
@@ -27,7 +27,7 @@ public class DiagnosticsRelic_Warforged extends AbstractWarforgedRelic {
     private final int CARDS_TO_ACTIVATE_BONUS = 5;
     private final int ENERGY_SHIELD_BONUS = 100;
 
-    BlockModContainer blockModContainer;
+    private final BlockModContainer blockModContainer;
 
     public DiagnosticsRelic_Warforged() {
         super(ID, NAME, RARITY, LANDING_SOUND);

--- a/src/main/java/thewarforged/util/WarforgedUtils.java
+++ b/src/main/java/thewarforged/util/WarforgedUtils.java
@@ -1,0 +1,55 @@
+package thewarforged.util;
+
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardGroup;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+
+import java.util.ArrayList;
+import java.util.Objects;
+
+public class WarforgedUtils {
+    private static final ArrayList<AbstractMonster.Intent> attackIntents;
+
+    static {
+        attackIntents = new ArrayList<>();
+        attackIntents.add(AbstractMonster.Intent.ATTACK);
+        attackIntents.add(AbstractMonster.Intent.ATTACK_BUFF);
+        attackIntents.add(AbstractMonster.Intent.ATTACK_DEBUFF);
+        attackIntents.add(AbstractMonster.Intent.ATTACK_DEFEND);
+    }
+
+    public WarforgedUtils() {
+    }
+
+    public static void easyPrint(String msg) {
+        easyPrint(msg, "+++++");
+    }
+
+    public static void easyPrint(String msg, String divider) {
+        System.out.println(divider);
+        System.out.println(msg);
+        System.out.println(divider);
+    }
+
+    /**
+     * Determines if the card group already contains at least one card with the same name
+     * as this card.
+     * @param group The card group to check (such as the player's master deck)
+     * @param card The card to check against the group
+     * @return True if the card group already contains at least one card with the same name
+     *      as this card; False otherwise
+     */
+    public static boolean doesGroupContainSimilarCard(CardGroup group, AbstractCard card) {
+        for (AbstractCard cardInGroup : group.group) {
+            if (Objects.equals(cardInGroup.name, card.name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isMonsterAttacking(AbstractMonster monster) {
+        if (monster == null) return false;
+        return (attackIntents.contains(monster.intent));
+    }
+}

--- a/src/main/resources/thewarforged/localization/eng/CardStrings.json
+++ b/src/main/resources/thewarforged/localization/eng/CardStrings.json
@@ -22,13 +22,17 @@
     "NAME": "Direct Current",
     "DESCRIPTION": "Deal !D! damage. NL Apply !M! ${modID}:Ionized."
   },
+  "${modID}:FluxNode_Warforged": {
+    "NAME": "Flux Node",
+    "DESCRIPTION": "${modID}:Replacement_Part NL Whenever you play a card that costs !M! [E] or more, gain !${modID}:DEX_GAIN! temporary Dexterity."
+  },
   "${modID}:Gyrospine_Warforged": {
     "NAME": "Gyrospine",
     "DESCRIPTION": "${modID}:Replacement_Part NL The next time you fall to half health or less, gain !M! Regen."
   },
   "${modID}:Neurolink_Warforged": {
     "NAME": "Neurolink",
-    "DESCRIPTION": "Whenever you attack an enemy that intends to attack, gain !M! ${modID}:Energy_Shield."
+    "DESCRIPTION": "${modID}:Replacement_Part NL Whenever you attack an enemy that intends to attack, gain !M! ${modID}:Energy_Shield."
   },
   "${modID}:RaiseShields_Warforged": {
     "NAME": "Raise Shields",

--- a/src/main/resources/thewarforged/localization/eng/CardStrings.json
+++ b/src/main/resources/thewarforged/localization/eng/CardStrings.json
@@ -38,6 +38,10 @@
     "NAME": "Strike",
     "DESCRIPTION": "Deal !D! damage."
   },
+  "${modID}:VeryParticularScrew_Warforged": {
+    "NAME": "Very Particular Screw",
+    "DESCRIPTION": "${modID}:Replacement_Part NL At the end of your turn, gain !M! Block."
+  },
 
 
 

--- a/src/main/resources/thewarforged/localization/eng/CardStrings.json
+++ b/src/main/resources/thewarforged/localization/eng/CardStrings.json
@@ -30,6 +30,10 @@
     "NAME": "Raise Shields",
     "DESCRIPTION": "Gain !B! ${modID}:Energy_Shield !M! times. NL Dexterity affects this card."
   },
+  "${modID}:StabilizeShields_Warforged": {
+    "NAME": "Stabilize Shields",
+    "DESCRIPTION": "Gain !B! ${modID}:Energy_Shield. NL ${modID}:Energy_Shield is not lost at the start of your next turn."
+  },
   "${modID}:Strike_Warforged": {
     "NAME": "Strike",
     "DESCRIPTION": "Deal !D! damage."

--- a/src/main/resources/thewarforged/localization/eng/CardStrings.json
+++ b/src/main/resources/thewarforged/localization/eng/CardStrings.json
@@ -26,6 +26,10 @@
     "NAME": "Gyrospine",
     "DESCRIPTION": "${modID}:Replacement_Part NL The next time you fall to half health or less, gain !M! Regen."
   },
+  "${modID}:Neurolink_Warforged": {
+    "NAME": "Neurolink",
+    "DESCRIPTION": "Whenever you attack an enemy that intends to attack, gain !M! ${modID}:Energy_Shield."
+  },
   "${modID}:RaiseShields_Warforged": {
     "NAME": "Raise Shields",
     "DESCRIPTION": "Gain !B! ${modID}:Energy_Shield !M! times. NL Dexterity affects this card."

--- a/src/main/resources/thewarforged/localization/eng/CardStrings.json
+++ b/src/main/resources/thewarforged/localization/eng/CardStrings.json
@@ -30,6 +30,11 @@
     "NAME": "Gyrospine",
     "DESCRIPTION": "${modID}:Replacement_Part NL The next time you fall to half health or less, gain !M! Regen."
   },
+  "${modID}:IonCoil_Warforged": {
+    "NAME": "Ion Coil",
+    "DESCRIPTION": "${modID}:Replacement_Part NL Whenever you apply ${modID}:Ionized, apply !M! additional ${modID}:Ionized.",
+    "UPGRADE_DESCRIPTION": "${modID}:Replacement_Part NL Whenever you apply ${modID}:Ionized, apply !M! additional ${modID}:Ionized, then the target loses !${modID}:HP_LOSS_VAR! * ${modID}:Ionized HP."
+  },
   "${modID}:Neurolink_Warforged": {
     "NAME": "Neurolink",
     "DESCRIPTION": "${modID}:Replacement_Part NL Whenever you attack an enemy that intends to attack, gain !M! ${modID}:Energy_Shield."

--- a/src/main/resources/thewarforged/localization/eng/Keywords.json
+++ b/src/main/resources/thewarforged/localization/eng/Keywords.json
@@ -29,7 +29,7 @@
     "DESCRIPTION": "After playing a card, lose HP equal to the number of [E] you have past 3. (This number can be affected by powers and relics)"
   },
   {
-    "ENERGY_SHIELDS": "Energy Shields",
+    "ENERGY_SHIELD": "Energy Shield",
     "NAMES": [
       "energy shield",
       "energy_shield",
@@ -43,7 +43,7 @@
       "ionized",
       "ionize"
     ],
-    "DESCRIPTION": "For each attack, also take half that attack's damage (rounded down) and reduce Ionize by 1."
+    "DESCRIPTION": "For each attack, also take half that attack's damage (rounded down) and reduce Ionized by 1."
   },
   {
     "LIVING_CONSTRUCT": "Living Construct",
@@ -59,7 +59,7 @@
       "overload",
       "overloaded"
     ],
-    "DESCRIPTION": "Every 6th card played in a turn is played twice. The copy does not trigger #yVolatile #yAether or #yAetherburn."
+    "DESCRIPTION": "Every 6th card played in a turn is played twice."
   },
   {
     "REPLACEMENT_PART": "Replacement Part",

--- a/src/main/resources/thewarforged/localization/eng/PowerStrings.json
+++ b/src/main/resources/thewarforged/localization/eng/PowerStrings.json
@@ -20,6 +20,20 @@
       " #yRegen."
     ]
   },
+  "${modID}:HighVoltagePower_Warforged": {
+    "NAME": "High Voltage",
+    "DESCRIPTIONS": [
+      "Whenever this creature applies #yIonized to another creature, that creature loses HP equal to #b",
+      " * their new #yIonized level."
+    ]
+  },
+  "${modID}:IonCoilPower_Warforged": {
+    "NAME": "Ion Coil",
+    "DESCRIPTIONS": [
+      "Whenever this creature applies #yIonized to another creature, #b",
+      " additional #yIonized is applied."
+    ]
+  },
   "${modID}:IonizedPower_Warforged": {
     "NAME": "Ionized",
     "DESCRIPTIONS": [

--- a/src/main/resources/thewarforged/localization/eng/PowerStrings.json
+++ b/src/main/resources/thewarforged/localization/eng/PowerStrings.json
@@ -19,5 +19,13 @@
       "Whenever this creature attacks, it takes",
       " damage equal to half of the attack damage (rounded down), then #yIonized is reduced by 1. This damage can be blocked."
     ]
+  },
+  "${modID}:StableShieldsPower_Warforged": {
+    "NAME": "Stable Shields",
+    "DESCRIPTIONS": [
+      "#yEnergy #yShield is not lost at the start of your next turn.",
+      "#yEnergy #yShield is not lost at the start of your next #b",
+      " turns."
+    ]
   }
 }

--- a/src/main/resources/thewarforged/localization/eng/PowerStrings.json
+++ b/src/main/resources/thewarforged/localization/eng/PowerStrings.json
@@ -20,6 +20,13 @@
       " damage equal to half of the attack damage (rounded down), then #yIonized is reduced by 1. This damage can be blocked."
     ]
   },
+  "${modID}:NeurolinkPower_Warforged": {
+    "NAME": "Neurolink",
+    "DESCRIPTIONS": [
+      "Whenever you attack an enemy, if that enemy intends to attack, gain #b",
+      " #yEnergy_Shield"
+    ]
+  },
   "${modID}:StableShieldsPower_Warforged": {
     "NAME": "Stable Shields",
     "DESCRIPTIONS": [

--- a/src/main/resources/thewarforged/localization/eng/PowerStrings.json
+++ b/src/main/resources/thewarforged/localization/eng/PowerStrings.json
@@ -5,6 +5,14 @@
       "You are Very Cool and Strong."
     ]
   },
+  "${modID}:FluxPower_Warforged": {
+    "NAME": "Flux Node",
+    "DESCRIPTIONS": [
+      "Whenever you play a card that costs #b",
+      " [E] or more, gain #b",
+      " temporary #yDexterity."
+    ]
+  },
   "${modID}:GyrospinePower_Warforged": {
     "NAME": "Gyrospine",
     "DESCRIPTIONS": [


### PR DESCRIPTION
Added 5 new Replacement Part cards (power cards) and one new skill card that was transitioned away from being a Replacement Part card.

Because all 5 new Replacement Part cards are power cards, many new powers (buffs) were created as well to support those, as well as other kinds of classes to support the necessary logic.